### PR TITLE
openFL path can now be retrieved from an .iml file

### DIFF
--- a/common/src/com/intellij/plugins/haxe/module/HaxeModuleSettingsBase.java
+++ b/common/src/com/intellij/plugins/haxe/module/HaxeModuleSettingsBase.java
@@ -69,7 +69,9 @@ public interface HaxeModuleSettingsBase {
 
   String getNmmlPath();
 
-  String getOpenFLXmlPath();
+  String getOpenFLPath();
+
+  void setOpenFLPath(String openFLPath);
 
   void setHxmlPath(String hxmlPath);
 

--- a/common/src/com/intellij/plugins/haxe/module/impl/HaxeModuleSettingsBaseImpl.java
+++ b/common/src/com/intellij/plugins/haxe/module/impl/HaxeModuleSettingsBaseImpl.java
@@ -43,7 +43,6 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
   protected OpenFLTarget openFLTarget = OpenFLTarget.FLASH;
   protected String hxmlPath = "";
   protected String nmmlPath = "";
-  protected String openflxmlPath = "";
   protected String openFLPath = "";
   protected int buildConfig = 0;
 
@@ -119,6 +118,12 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
     return openFLFlags;
   }
 
+  public void setOpenFLPath(String openFLPath) { this.openFLPath = openFLPath; }
+
+  public String getOpenFLPath() {
+    return openFLPath;
+  }
+
   public void setOpenFLTarget(OpenFLTarget target) {
     this.openFLTarget = target;
   }
@@ -126,7 +131,6 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
   public OpenFLTarget getOpenFLTarget() {
     return openFLTarget;
   }
-
 
   public HaxeTarget getHaxeTarget() {
     return haxeTarget;
@@ -168,10 +172,6 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
     return nmmlPath;
   }
 
-  public String getOpenFLXmlPath() {
-    return openflxmlPath;
-  }
-
   public void setHxmlPath(String hxmlPath) {
     this.hxmlPath = hxmlPath;
   }
@@ -194,10 +194,6 @@ public class HaxeModuleSettingsBaseImpl implements HaxeModuleSettingsBase {
 
   public void setNmmlPath(String nmmlPath) {
     this.nmmlPath = nmmlPath;
-  }
-
-  public void setOpenFLXMLPath(String openflxmlPath) {
-    this.openflxmlPath = openflxmlPath;
   }
 
   public void setBuildConfig(int buildConfig) {

--- a/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -275,8 +275,8 @@ public class HaxeCommonCompilerUtil {
     commandLine.add("lime");
     commandLine.add("build");
 
-    if(!StringUtil.isEmpty(settings.getOpenFLXmlPath())) {
-      commandLine.add(settings.getOpenFLXmlPath());
+    if(!StringUtil.isEmpty(settings.getOpenFLPath())) {
+      commandLine.add(settings.getOpenFLPath());
     }
 
     commandLine.add(settings.getOpenFLTarget().getTargetFlag());

--- a/jps-plugin/src/org/jetbrains/jps/haxe/model/module/impl/JpsHaxeModuleSettingsImpl.java
+++ b/jps-plugin/src/org/jetbrains/jps/haxe/model/module/impl/JpsHaxeModuleSettingsImpl.java
@@ -89,6 +89,15 @@ public class JpsHaxeModuleSettingsImpl extends JpsElementBase<JpsHaxeModuleSetti
     mySettingsBase.setOpenFLFlags(flags);
   }
 
+  @Override
+  public String getOpenFLPath() {
+    return mySettingsBase.getOpenFLPath();
+  }
+
+  @Override
+  public void setOpenFLPath(String openFLPath) {
+    mySettingsBase.setOpenFLPath(openFLPath);
+  }
 
   @Override
   public HaxeTarget getHaxeTarget() {
@@ -145,11 +154,6 @@ public class JpsHaxeModuleSettingsImpl extends JpsElementBase<JpsHaxeModuleSetti
   @Override
   public String getNmmlPath() {
     return mySettingsBase.getNmmlPath();
-  }
-
-  @Override
-  public String getOpenFLXmlPath() {
-    return mySettingsBase.getOpenFLXmlPath();
   }
 
   @Override

--- a/src/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.java
+++ b/src/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.java
@@ -378,7 +378,7 @@ public class HaxeConfigurationEditor {
 
     result = result || !FileUtil.toSystemIndependentName(myHxmlFileChooserTextField.getText()).equals(settings.getHxmlPath());
 
-    result = result || !FileUtil.toSystemIndependentName(myOpenFLFileChooserTextField.getText()).equals(settings.getOpenFLXmlPath());
+    result = result || !FileUtil.toSystemIndependentName(myOpenFLFileChooserTextField.getText()).equals(settings.getOpenFLPath());
 
     result = result || !settings.getArguments().equals(myAppArguments.getText());
     result = result || !settings.getNmeFlags().equals(myNMEArguments.getText());
@@ -413,7 +413,7 @@ public class HaxeConfigurationEditor {
     final String url = myExtension.getCompilerOutputUrl();
     myFolderTextField.setText(VfsUtil.urlToPath(url));
     myHxmlFileChooserTextField.setText(settings.getHxmlPath());
-    myOpenFLFileChooserTextField.setText(settings.getOpenFLXmlPath());
+    myOpenFLFileChooserTextField.setText(settings.getOpenFLPath());
     myNMEFileChooserTextField.setText(settings.getNmmlPath());
     myNMEArguments.setText(settings.getNmeFlags());
 
@@ -445,7 +445,7 @@ public class HaxeConfigurationEditor {
     settings.setOutputFolder(myFolderTextField.getText());
 
     settings.setHxmlPath(FileUtil.toSystemIndependentName(myHxmlFileChooserTextField.getText()));
-    settings.setOpenFLXMLPath(FileUtil.toSystemIndependentName(myOpenFLFileChooserTextField.getText()));
+    settings.setOpenFLPath(FileUtil.toSystemIndependentName(myOpenFLFileChooserTextField.getText()));
     settings.setNmmlPath(FileUtil.toSystemIndependentName(myNMEFileChooserTextField.getText()));
 
     settings.setBuildConfig(getCurrentBuildConfig());

--- a/src/com/intellij/plugins/haxe/runner/OpenFLRunningState.java
+++ b/src/com/intellij/plugins/haxe/runner/OpenFLRunningState.java
@@ -85,8 +85,8 @@ public class OpenFLRunningState extends CommandLineState {
     commandLine.addParameter("lime");
     commandLine.addParameter(myRunInTest ? "test" : "run");
 
-    if(!StringUtil.isEmpty(settings.getOpenFLXmlPath())) {
-      commandLine.addParameter(settings.getOpenFLXmlPath());
+    if(!StringUtil.isEmpty(settings.getOpenFLPath())) {
+      commandLine.addParameter(settings.getOpenFLPath());
     }
 
     for (String flag : settings.getOpenFLTarget().getFlags()) {


### PR DESCRIPTION
I'm working on getting the plugin to build openFL projects. This commit allows to set an "openFLPath" field in the generated .iml files which will be used as the path to the project.xml file
