### PR TITLE
Better editor: Insert parens on function completion. Fix doubling quotes on string closing.

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
@@ -24,6 +24,8 @@ import com.intellij.codeInsight.lookup.LookupElementPresentation;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.plugins.haxe.build.FieldWrapper;
+import com.intellij.plugins.haxe.build.IdeaTarget;
 import com.intellij.plugins.haxe.lang.psi.HaxeClassResolveResult;
 import com.intellij.plugins.haxe.lang.psi.HaxeComponentName;
 import com.intellij.plugins.haxe.model.HaxeMemberModel;
@@ -131,8 +133,11 @@ public class HaxeLookupElement extends LookupElement {
       JavaCompletionUtil.insertParentheses(context, this, overloadsMatter, hasParams);
     }
   }
-  // Workaround for IDEA 14. There must be JavaCompletionUtil.FORCE_SHOW_SIGNATURE_ATTR
-  private static final Key<Boolean> FORCE_SHOW_SIGNATURE_ATTR = Key.create("forceShowSignature");
+
+  private static final Key<Boolean> FORCE_SHOW_SIGNATURE_ATTR =
+    IdeaTarget.IS_VERSION_15_COMPATIBLE ? new FieldWrapper<Key<Boolean>>(JavaCompletionUtil.class,
+                                                                         "FORCE_SHOW_SIGNATURE_ATTR").get(null)
+                                        : Key.<Boolean>create("forceShowSignature");
 
   @NotNull
   @Override

--- a/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
@@ -22,6 +22,7 @@ import com.intellij.codeInsight.completion.JavaCompletionUtil;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementPresentation;
 import com.intellij.navigation.ItemPresentation;
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.plugins.haxe.lang.psi.HaxeClassResolveResult;
 import com.intellij.plugins.haxe.lang.psi.HaxeComponentName;
@@ -126,10 +127,12 @@ public class HaxeLookupElement extends LookupElement {
 
     if (isMethod) {
       final LookupElement[] allItems = context.getElements();
-      final boolean overloadsMatter = allItems.length == 1 && getUserData(JavaCompletionUtil.FORCE_SHOW_SIGNATURE_ATTR) == null;
+      final boolean overloadsMatter = allItems.length == 1 && getUserData(FORCE_SHOW_SIGNATURE_ATTR) == null;
       JavaCompletionUtil.insertParentheses(context, this, overloadsMatter, hasParams);
     }
   }
+  // Workaround for IDEA 14. There must be JavaCompletionUtil.FORCE_SHOW_SIGNATURE_ATTR
+  private static final Key<Boolean> FORCE_SHOW_SIGNATURE_ATTR = Key.create("forceShowSignature");
 
   @NotNull
   @Override

--- a/src/common/com/intellij/plugins/haxe/ide/HaxeQuoteHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeQuoteHandler.java
@@ -18,15 +18,13 @@
 package com.intellij.plugins.haxe.ide;
 
 import com.intellij.codeInsight.editorActions.SimpleTokenSetQuoteHandler;
-import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypeSets;
-import com.intellij.psi.TokenType;
-import com.intellij.util.ArrayUtil;
+import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 
 /**
  * @author fedor.korotkov
  */
 public class HaxeQuoteHandler extends SimpleTokenSetQuoteHandler {
   public HaxeQuoteHandler() {
-    super(ArrayUtil.append(HaxeTokenTypeSets.STRINGS.getTypes(), TokenType.BAD_CHARACTER));
+    super(HaxeTokenTypes.OPEN_QUOTE);
   }
 }


### PR DESCRIPTION
Some minor enhancements to code editor:

1. Smart insert parens for functions like in Java editor.
Case A: Function `foo()` without parameters. On autocomplete you got `foo()|`
Case B: Function `foo(a: Int)` with parameter(s). On autocomplete you got `foo(|)`

2. Fix doubling quotes when closing string literal.
Imagine, you code a string `"foo`. And now you want to close it and type `"`. And yes, you got `"foo"`, not a `"foo""`

