### PR TITLE
FIX @:require @:jsRequire typed argument list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,6 @@ env:
     - IDEA_VERSION=15.0.6 ANT_TARGET=compile_test
     - IDEA_VERSION=2016.1.4 ANT_TARGET=compile_test
     - IDEA_VERSION=2016.2.5 ANT_TARGET=test
-    - IDEA_VERSION=2016.3.4 ANT_TARGET=test
+    - IDEA_VERSION=2016.3.5 ANT_TARGET=test
 notifications:
   email: false

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -205,7 +205,7 @@ private macroMember ::= macroMeta | protectedMeta | debugMeta | noDebugMeta | ke
 
 buildMacro ::= '@:build' '(' referenceExpression (callExpression | arrayAccessExpression | qualifiedReferenceExpression)* ')' {pin=2}
 autoBuildMacro ::= '@:autoBuild' '(' referenceExpression (callExpression | arrayAccessExpression | qualifiedReferenceExpression)* ')' {pin=2}
-requireMeta ::=  '@:require' '(' identifier ')'
+requireMeta ::=  '@:require' '(' identifier (',' identifier)* ')'
 fakeEnumMeta ::=  '@:fakeEnum' '(' type ')'
 nativeMeta ::=  '@:native' '(' stringLiteralExpression ')'
 bitmapMeta ::= '@:bitmap' '(' stringLiteralExpression ')'
@@ -218,7 +218,7 @@ metaMeta ::= '@:meta' '(' ID '(' metaPartList? ')' ')'
 private metaPartList ::= metaKeyValue (',' metaKeyValue)*
 metaKeyValue ::= ID '=' stringLiteralExpression
 
-jsRequireMeta ::= "@:jsRequire" '(' stringLiteralExpression ')'
+jsRequireMeta ::= "@:jsRequire" '(' stringLiteralExpression (',' stringLiteralExpression)* ')'
 
 private metaKeyWord ::= MACRO_ID | '@:final' | '@:hack' | '@:native' | '@:macro' | '@:build' | '@:autoBuild' | '@:keep' | '@:require' | '@:fakeEnum' | '@:core_api' | '@:bind' | '@:bitmap' | '@:ns' | '@:protected' | '@:getter' | '@:setter' | '@:debug' | '@:nodebug' | '@:meta' | '@:overload' | '@:jsRequire'
 


### PR DESCRIPTION
`@:require` and `@:jsRequire` allow to use multiple arguments. Currently BNF allow only one argument and js extern generated libraries parsing is broken.
![image](https://cloud.githubusercontent.com/assets/3038174/24359106/03e106e4-130c-11e7-9921-48747f0f2e93.png)

For example this library as example: https://github.com/fponticelli/hxelectron is really hard to use because of all meta broke parsing.