### PR TITLE
fix #418

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -205,7 +205,9 @@ private macroMember ::= macroMeta | protectedMeta | debugMeta | noDebugMeta | ke
 
 buildMacro ::= '@:build' '(' referenceExpression (callExpression | arrayAccessExpression | qualifiedReferenceExpression)* ')' {pin=2}
 autoBuildMacro ::= '@:autoBuild' '(' referenceExpression (callExpression | arrayAccessExpression | qualifiedReferenceExpression)* ')' {pin=2}
-requireMeta ::=  '@:require' '(' identifier (',' identifier)* ')'
+private haxeVerExpr ::= 'haxe_ver' compareOperation LITFLOAT
+private identifierList ::= identifier (',' identifier)*
+requireMeta ::=  '@:require' '(' (haxeVerExpr | identifierList) ')'
 fakeEnumMeta ::=  '@:fakeEnum' '(' type ')'
 nativeMeta ::=  '@:native' '(' stringLiteralExpression ')'
 bitmapMeta ::= '@:bitmap' '(' stringLiteralExpression ')'

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -39,6 +39,8 @@
       <p/>
       <p>Unreleased (Feature test):</p>
       <ul>
+        <li>Support for `@:require` haxe_ver comparing (issue #418)</li>
+        <li>Support for `@:require` and `@:jsRequire` with multiple arguments</li>
         <li>Reworked code completion using the compiler -- OFF BY DEFAULT!  Turn on in File->Project Structure...</li>
         <li>Better handling of closing parens, brackets, quotes. (Issues #545, 546)</li>
         <li>Fix parsing when an anonymous function call is defined and immediately executed. (Issue #544)</li>

--- a/testData/parsing/haxe/declarations/class/FullOfMacro.hx
+++ b/testData/parsing/haxe/declarations/class/FullOfMacro.hx
@@ -5,6 +5,8 @@
 @:meta(Event(name="test",type="Foo"))
 @:bitmap("myfile.png")
 @:build(MacroGenerator.build())
+@:require(dep1, dep2, dep3)
+@:require(haxe_ver >= 3.2)
 @superClass("user name", {name:"user"})
 class FullOfMacro {
   @customUser

--- a/testData/parsing/haxe/declarations/class/FullOfMacro.txt
+++ b/testData/parsing/haxe/declarations/class/FullOfMacro.txt
@@ -7,6 +7,8 @@ Haxe File
 @:meta(Event(name="test",type="Foo"))
 @:bitmap("myfile.png")
 @:build(MacroGenerator.build())
+@:require(dep1, dep2, dep3)
+@:require(haxe_ver >= 3.2)
 @superClass("user name", {name:"user"})
       MACRO_CLASS
         SIMPLE_META
@@ -85,6 +87,29 @@ Haxe File
                   PsiJavaToken:ID('build')
             PsiJavaToken:(('(')
             PsiJavaToken:)(')')
+          PsiJavaToken:)(')')
+      MACRO_CLASS
+        REQUIRE_META
+          PsiJavaToken:@:require('@:require')
+          PsiJavaToken:(('(')
+          IDENTIFIER
+            PsiJavaToken:ID('dep1')
+          PsiJavaToken:,(',')
+          IDENTIFIER
+            PsiJavaToken:ID('dep2')
+          PsiJavaToken:,(',')
+          IDENTIFIER
+            PsiJavaToken:ID('dep3')
+          PsiJavaToken:)(')')
+      MACRO_CLASS
+        REQUIRE_META
+          PsiJavaToken:@:require('@:require')
+          PsiJavaToken:(('(')
+          PsiJavaToken:ID('haxe_ver')
+          COMPARE_OPERATION
+            PsiJavaToken:>('>')
+            PsiJavaToken:=('=')
+          PsiJavaToken:LITFLOAT('3.2')
           PsiJavaToken:)(')')
       MACRO_CLASS
         CUSTOM_META


### PR DESCRIPTION
- `@:require` support for `haxe_ver` comparing, it heals all broken Std completion with `@:require(haxe_ver >= X.X)` meta. For example `haxe.macro.Context` methods

- test added
- release notes updated