### PR TITLE
Fixed IllegalArgumentException

### DIFF
--- a/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -189,13 +189,15 @@ public class HaxeCommonCompilerUtil {
 
     // Show the command line in the output window.
     // TODO: Make a checkbox in the SDK configuration window.
+    String commandLineString = "";
+
     if (!commandLine.isEmpty()) {
-      StringBuilder cl = new StringBuilder("Executing: ");
+      StringBuilder cl = new StringBuilder();
       for (String commandPart : commandLine) {
         cl.append(commandPart);
         cl.append(" ");
       }
-      context.infoHandler(cl.toString());
+      commandLineString = cl.toString();
     }
 
     final BooleanValueHolder hasErrors = new BooleanValueHolder(false);
@@ -207,7 +209,7 @@ public class HaxeCommonCompilerUtil {
       }
       final BaseOSProcessHandler handler = new ColoredProcessHandler(
         HaxeSdkUtilBase.createProcessBuilder(commandLine, workingDirectory, context.getHaxeSdkData()).start(),
-        null,
+        commandLineString,
         Charset.defaultCharset()
       );
 


### PR DESCRIPTION
BaseOSProcessHandler sending notify into console by itself with passed argument commandLine, and it shouldn't be null.

```
java.lang.IllegalArgumentException: Must specify non-empty 'commandLine' parameter
	at com.intellij.execution.process.BaseOSProcessHandler.<init>(BaseOSProcessHandler.java:65)
	at com.intellij.execution.process.OSProcessHandler.<init>(OSProcessHandler.java:67)
	at com.intellij.execution.process.KillableProcessHandler.<init>(KillableProcessHandler.java:67)
	at com.intellij.execution.process.ColoredProcessHandler.<init>(ColoredProcessHandler.java:54)
	at com.intellij.plugins.haxe.util.HaxeCommonCompilerUtil.compile(HaxeCommonCompilerUtil.java:211)
	at com.intellij.plugins.haxe.compilation.HaxeCompiler.compileModule(HaxeCompiler.java:177)
	at com.intellij.plugins.haxe.compilation.HaxeCompiler.run(HaxeCompiler.java:140)
	at com.intellij.plugins.haxe.compilation.HaxeCompiler.process(HaxeCompiler.java:124)
	at com.intellij.plugins.haxe.compilation.HaxeCompilerTask.execute(HaxeCompilerTask.java:38)
	at com.intellij.compiler.impl.CompileDriver.a(CompileDriver.java:578)
	at com.intellij.compiler.impl.CompileDriver.a(CompileDriver.java:396)
	at com.intellij.compiler.progress.CompilerTask.run(CompilerTask.java:196)
```