### PR TITLE
Temporally commented casting that leads to ClassCastException

### DIFF
--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxeNamedComponent.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxeNamedComponent.java
@@ -235,7 +235,11 @@ abstract public class AbstractHaxeNamedComponent extends HaxePsiCompositeElement
   @Nullable
   public ASTNode findChildByRole(int role) {
     // assert ChildRole.isUnique(role);
-    for (ASTNode child = getFirstChild().getNode(); child != null; child = child.getTreeNext()) {
+    PsiElement firstChild = getFirstChild();
+
+    if (firstChild == null) return null;
+
+    for (ASTNode child = firstChild.getNode(); child != null; child = child.getTreeNext()) {
       if (getChildRole(child) == role) return child;
     }
     return null;

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
@@ -22,6 +22,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Pair;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.PsiSuperMethodImplUtil;
 import com.intellij.psi.impl.source.tree.java.PsiTypeParameterImpl;
@@ -100,11 +101,15 @@ public class HaxeTypeListPartPsiMixinImpl extends HaxePsiCompositeElementImpl im
             LOG.assertTrue(false, "Unexpected token type for child of TYPE_OR_ANONYMOUS");
             myChildClass = AbstractHaxePsiClass.EMPTY_FACADE;
           }
-
         } else if (HaxeTokenTypes.FUNCTION_TYPE.equals(type)) {
-          // TODO: Fix this.  Temporary hack in place so I can test.
-          //myChildClass = (HaxeAnonymousType) child;
-          myChildClass = AbstractHaxePsiClass.EMPTY_FACADE;
+          // FIXME: Temporary Hack to get around an unexpected PSI state #627.
+          try {
+            myChildClass = (HaxeAnonymousType) child;
+          }
+          catch(ClassCastException e) {
+            HaxeDebugLogger.getLogger().warn("Unexpected PSI state.  See issue #627");
+            myChildClass = AbstractHaxePsiClass.EMPTY_FACADE;
+          }
         } else {
           myChildClass = AbstractHaxePsiClass.EMPTY_FACADE;
         }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
@@ -103,7 +103,8 @@ public class HaxeTypeListPartPsiMixinImpl extends HaxePsiCompositeElementImpl im
 
         } else if (HaxeTokenTypes.FUNCTION_TYPE.equals(type)) {
           // TODO: Fix this.  Temporary hack in place so I can test.
-          myChildClass = (HaxeAnonymousType) child;
+          //myChildClass = (HaxeAnonymousType) child;
+          myChildClass = AbstractHaxePsiClass.EMPTY_FACADE;
         } else {
           myChildClass = AbstractHaxePsiClass.EMPTY_FACADE;
         }


### PR DESCRIPTION
Even if problem with function return type not solved it mustn't throw an exception.

Code to reproduce:
```
package;

class Test {
   private var array:Array<Bool->Void>;
   public function new() {
   }
} 
```
Exception:
```
com.intellij.plugins.haxe.lang.psi.impl.HaxeFunctionTypeImpl cannot be cast to com.intellij.plugins.haxe.lang.psi.HaxeAnonymousType
java.lang.ClassCastException: com.intellij.plugins.haxe.lang.psi.impl.HaxeFunctionTypeImpl cannot be cast to com.intellij.plugins.haxe.lang.psi.HaxeAnonymousType
	at com.intellij.plugins.haxe.lang.psi.impl.HaxeTypeListPartPsiMixinImpl.getDelegate(HaxeTypeListPartPsiMixinImpl.java:106)
	at com.intellij.plugins.haxe.lang.psi.impl.HaxeTypeListPartPsiMixinImpl.getDocComment(HaxeTypeListPartPsiMixinImpl.java:267)
	at com.intellij.codeInspection.JavaSuppressionUtil.getSuppressedInspectionIdsIn(JavaSuppressionUtil.java:198)
	at com.intellij.codeInspection.SuppressManagerImpl.getSuppressedInspectionIdsIn(SuppressManagerImpl.java:83)
	at com.intellij.codeInspection.ex.JavaInspectionExtensionsFactory.getSuppressedInspectionIdsIn(JavaInspectionExtensionsFactory.java:62)
	at com.intellij.codeInspection.ex.EditInspectionToolsSettingsInSuppressedPlaceIntention.a(EditInspectionToolsSettingsInSuppressedPlaceIntention.java:58)
	at com.intellij.codeInspection.ex.EditInspectionToolsSettingsInSuppressedPlaceIntention.isAvailable(EditInspectionToolsSettingsInSuppressedPlaceIntention.java:81)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.availableFor(ShowIntentionActionsHandler.java:132)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.a(ShowIntentionsPass.java:312)
	at com.intellij.codeInsight.intention.impl.ShowIntentionActionsHandler.chooseBetweenHostAndInjected(ShowIntentionActionsHandler.java:157)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.getActionsToShow(ShowIntentionsPass.java:311)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.a(ShowIntentionsPass.java:243)
	at com.intellij.codeInsight.daemon.impl.ShowIntentionsPass.doCollectInformation(ShowIntentionsPass.java:219)
	at com.intellij.codeHighlighting.TextEditorHighlightingPass.collectInformation(TextEditorHighlightingPass.java:70)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.b(PassExecutorService.java:433)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1061)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.c(PassExecutorService.java:426)
	at com.intellij.openapi.progress.impl.CoreProgressManager.a(CoreProgressManager.java:568)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:519)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:54)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.a(PassExecutorService.java:425)
	at com.intellij.codeInsight.daemon.impl.PassExecutorService$ScheduledPass.run(PassExecutorService.java:405)
	at com.intellij.concurrency.JobLauncherImpl$VoidForkJoinTask$1.exec(JobLauncherImpl.java:155)
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
	at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
```