### PR TITLE
Update TravisCI build configuration.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
+sudo: required
 language: java
 jdk:
 - oraclejdk8
 before_script:
+- sudo apt-get -qq update
+- sudo apt-get install ant-optional -y
 - sudo add-apt-repository ppa:eyecreate/haxe -y
 - sudo apt-get update
 - sudo apt-get install haxe -y


### PR DESCRIPTION
Add ant-optional to the TravisCI build, because it was removed from the default configuration.