### PR TITLE
Parameters info improvement

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -352,15 +352,16 @@ propertyAccessor ::= 'null' | 'default' | 'dynamic' | 'never' | 'get' | 'set' | 
 
 private functionCommonBody ::= blockStatement | returnStatement | (expression ';'?) | throwStatement | ifStatement | forStatement | whileStatement | doWhileStatement
 
-private constructorName ::= 'new'
+constructorName ::= 'new' {elementType=identifier}
+constructorComponentName ::= constructorName {elementType=componentName}
 
 private localFunctionDeclarationAttribute ::= 'inline';
 
-externFunctionDeclaration ::= (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? (functionCommonBody | ';')
+externFunctionDeclaration ::= (functionMacroMember| declarationAttribute)* 'function' (constructorComponentName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? (functionCommonBody | ';')
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
-functionDeclarationWithAttributes ::= (functionMacroMember | declarationAttribute)* 'function' (constructorName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? functionCommonBody
+functionDeclarationWithAttributes ::= (functionMacroMember | declarationAttribute)* 'function' (constructorComponentName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? functionCommonBody
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
-functionPrototypeDeclarationWithAttributes ::= (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? ';'
+functionPrototypeDeclarationWithAttributes ::= (functionMacroMember| declarationAttribute)* 'function' (constructorComponentName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? ';'
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
 localFunctionDeclaration ::= localFunctionDeclarationAttribute? 'function' componentName genericParam? parenthesizedParameterList typeTag? 'untyped'? functionCommonBody
 {pin=2 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -352,16 +352,15 @@ propertyAccessor ::= 'null' | 'default' | 'dynamic' | 'never' | 'get' | 'set' | 
 
 private functionCommonBody ::= blockStatement | returnStatement | (expression ';'?) | throwStatement | ifStatement | forStatement | whileStatement | doWhileStatement
 
-constructorName ::= 'new' {elementType=identifier}
-constructorComponentName ::= constructorName {elementType=componentName}
+private constructorName ::= 'new'
 
 private localFunctionDeclarationAttribute ::= 'inline';
 
-externFunctionDeclaration ::= (functionMacroMember| declarationAttribute)* 'function' (constructorComponentName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? (functionCommonBody | ';')
+externFunctionDeclaration ::= (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? (functionCommonBody | ';')
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
-functionDeclarationWithAttributes ::= (functionMacroMember | declarationAttribute)* 'function' (constructorComponentName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? functionCommonBody
+functionDeclarationWithAttributes ::= (functionMacroMember | declarationAttribute)* 'function' (constructorName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? functionCommonBody
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
-functionPrototypeDeclarationWithAttributes ::= (functionMacroMember| declarationAttribute)* 'function' (constructorComponentName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? ';'
+functionPrototypeDeclarationWithAttributes ::= (functionMacroMember| declarationAttribute)* 'function' (constructorName | componentName) genericParam? parenthesizedParameterList typeTag? 'untyped'? ';'
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}
 localFunctionDeclaration ::= localFunctionDeclarationAttribute? 'function' componentName genericParam? parenthesizedParameterList typeTag? 'untyped'? functionCommonBody
 {pin=2 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeMethod"}

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -374,7 +374,8 @@ private arrowFunctionDeclaration ::=  arrowFunctionParameterList '->' functionCo
  */
 
 varInit ::= '=' expression {pin=1}
-parameter ::= '?'? componentName typeTag? varInit?
+isOptional ::= '?'
+parameter ::= isOptional? componentName typeTag? varInit?
 {mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeParameterPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeParameterPsiMixin"}
 
 openParameterList ::= parameter {extends=parameterList}

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -374,8 +374,7 @@ private arrowFunctionDeclaration ::=  arrowFunctionParameterList '->' functionCo
  */
 
 varInit ::= '=' expression {pin=1}
-isOptional ::= '?'
-parameter ::= isOptional? componentName typeTag? varInit?
+parameter ::= '?'? componentName typeTag? varInit?
 {mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeParameterPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeParameterPsiMixin"}
 
 openParameterList ::= parameter {extends=parameterList}

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -623,7 +623,8 @@ thisExpression ::= 'this'
 superExpression ::= 'super'
 {mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeReference"}
 
-newExpression ::= 'new' type '(' (expression (',' expression)*)? ')'
+private newExpressionArgumentsList ::= '(' [!')' expression (',' expression)*] ')' {pin(".*")=1}
+newExpression ::= 'new' type newExpressionArgumentsList
 {pin=2 recoverWhile="expression_recover" mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeReference"}
 
 castExpression ::= 'cast' (('(' expression ',' typeWrapper ')')  | expression)

--- a/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -166,3 +166,6 @@ haxe.semantic.implemented.method.parameter.required=Expected: ''{0}''. Parameter
 haxe.semantic.method.parameter.optional.add=Declare parameter as optional
 haxe.semantic.method.parameter.optional.remove=Remove "optional" mark from parameter declaration
 haxe.semantic.implemented.super.method.signature.differs=Signature of inherited method ''{0}'' declared by class ''{1}'' differs from declared by interface. Expected ''{2}'', got ''{3}''
+
+# HAXE parameter info helper
+haxe.parameter.info.helper.no.parameters=No parameters

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescription.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescription.java
@@ -22,8 +22,6 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.plugins.haxe.HaxeBundle;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.logging.Logger;
-
 public class HaxeFunctionDescription {
   private static final TextRange ZERO_TEXT_RANGE = new TextRange(0, 0);
   private static final String PARAMETERS_DELIMITER = ", ";
@@ -33,18 +31,18 @@ public class HaxeFunctionDescription {
   private final String description;
   private final TextRange[] parametersTextRange;
 
-  HaxeFunctionDescription(HaxeParameterDescription[] parameters) {
+  HaxeFunctionDescription(@Nullable HaxeParameterDescription[] parameters) {
     this.parameters = parameters;
-    this.parametersTextRange = new TextRange[parameters.length];
+    this.parametersTextRange = parameters == null ? null : new TextRange[parameters.length];
 
-    this.description = compileDescription();
+    this.description = compilePresentableDescription();
   }
-
+  
   public HaxeParameterDescription[] getParameters() {
     return parameters;
   }
 
-  private String compileDescription() {
+  private String compilePresentableDescription() {
     final StringBuilder result = new StringBuilder();
 
     int currentOffset = 0;
@@ -55,7 +53,7 @@ public class HaxeFunctionDescription {
 
     for (int i = 0; i < parameters.length; i++) {
       HaxeParameterDescription parameter = parameters[i];
-      String description = parameter.toString();
+      String description = parameter.getPresentableText();
       int descriptionLength = description.length();
 
       parametersTextRange[i] = new TextRange(currentOffset, currentOffset + descriptionLength);
@@ -81,6 +79,10 @@ public class HaxeFunctionDescription {
 
   @Override
   public String toString() {
+    return getPresentableText();
+  }
+
+  public String getPresentableText() {
     return description;
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescription.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescription.java
@@ -19,6 +19,7 @@
 package com.intellij.plugins.haxe.ide.info;
 
 import com.intellij.openapi.util.TextRange;
+import com.intellij.plugins.haxe.HaxeBundle;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.logging.Logger;
@@ -27,30 +28,16 @@ public class HaxeFunctionDescription {
   private static final TextRange ZERO_TEXT_RANGE = new TextRange(0, 0);
   private static final String PARAMETERS_DELIMITER = ", ";
 
-  private final String name;
-  private final String returnType;
   private final HaxeParameterDescription[] parameters;
 
   private final String description;
   private final TextRange[] parametersTextRange;
 
-  HaxeFunctionDescription(String name, @Nullable String returnType, HaxeParameterDescription[] parameters) {
-    this.name = name;
-    this.returnType = returnType;
-
+  HaxeFunctionDescription(HaxeParameterDescription[] parameters) {
     this.parameters = parameters;
     this.parametersTextRange = new TextRange[parameters.length];
 
     this.description = compileDescription();
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  @Nullable
-  public String getReturnType() {
-    return returnType;
   }
 
   public HaxeParameterDescription[] getParameters() {
@@ -61,6 +48,10 @@ public class HaxeFunctionDescription {
     final StringBuilder result = new StringBuilder();
 
     int currentOffset = 0;
+
+    if (parameters.length == 0) {
+      return HaxeBundle.message("haxe.parameter.info.helper.no.parameters");
+    }
 
     for (int i = 0; i < parameters.length; i++) {
       HaxeParameterDescription parameter = parameters[i];
@@ -90,7 +81,6 @@ public class HaxeFunctionDescription {
 
   @Override
   public String toString() {
-    Logger.getGlobal().info(description);
     return description;
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
@@ -33,8 +33,9 @@ class HaxeFunctionDescriptionBuilder {
     final PsiElement target = reference.resolve();
 
     if (target instanceof HaxeMethod) {
-      final HaxeClassResolveResult resolveResult = reference.resolveHaxeClass();
-      return build((HaxeMethod)target, resolveResult, specialization, isStaticExtension);
+      final HaxeClass haxeClass = (HaxeClass)((HaxeMethod)target).getContainingClass();
+      final HaxeClassResolveResult resolveResult = HaxeClassResolveResult.create(haxeClass, specialization);
+      return build((HaxeMethod)target, resolveResult, isStaticExtension);
     }
     return null;
   }
@@ -47,17 +48,20 @@ class HaxeFunctionDescriptionBuilder {
     if (haxeClass != null) {
       final PsiMethod[] constructors = haxeClass.getConstructors();
       if (constructors.length > 0) {
-        final HaxeMethod constructor = (HaxeMethod)constructors[0];
         final HaxeClassResolveResult resolveResult = HaxeClassResolveResult.create(haxeClass, specialization);
 
-        return build(constructor, resolveResult, specialization, false);
+        final HaxeMethod constructor = (HaxeMethod)constructors[0];
+        return build(constructor, resolveResult, false);
       }
     }
 
     return null;
   }
 
-  private static HaxeFunctionDescription build(HaxeMethod method, HaxeClassResolveResult resolveResult, HaxeGenericSpecialization specialization, boolean isExtension) {
+  private static HaxeFunctionDescription build(HaxeMethod method,
+                                               HaxeClassResolveResult resolveResult,
+                                               boolean isExtension) {
+
     HaxeParameterDescription[] parameterDescriptions = null;
 
     final HaxeParameterList parameterList = PsiTreeUtil.getChildOfType(method, HaxeParameterList.class);
@@ -66,8 +70,7 @@ class HaxeFunctionDescriptionBuilder {
       if (isExtension) {
         list.remove(0);
       }
-
-      parameterDescriptions = HaxeParameterDescriptionBuilder.buildFromList(list, specialization);
+      parameterDescriptions = HaxeParameterDescriptionBuilder.buildFromList(list, resolveResult);
     }
 
     return new HaxeFunctionDescription(parameterDescriptions);

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017-2017 Ilya Malanin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.ide.info;
+
+import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.HaxePresentableUtil;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiMethod;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+
+class HaxeFunctionDescriptionBuilder {
+  @Nullable
+  static HaxeFunctionDescription buildForMethod(HaxeCallExpression expression) {
+    final HaxeGenericSpecialization specialization = expression.getSpecialization();
+    final boolean isStaticExtension = expression.resolveIsStaticExtension();
+
+    final PsiElement target = ((HaxeReference)expression.getExpression()).resolve();
+
+    if (target instanceof HaxeMethod) {
+      final HaxeClass targetParent = (HaxeClass)((HaxeMethod)target).getContainingClass();
+      final HaxeClassResolveResult resolveResult = HaxeClassResolveResult.create(targetParent, specialization);
+
+      return build((HaxeMethod)target, resolveResult, specialization, isStaticExtension);
+    }
+    return null;
+  }
+
+  @Nullable
+  static HaxeFunctionDescription buildForConstructor(final HaxeNewExpression expression) {
+    final HaxeGenericSpecialization specialization = expression.getSpecialization();
+    final HaxeClass haxeClass = (HaxeClassDeclaration)expression.getType().getReferenceExpression().resolve();
+
+    if (haxeClass != null) {
+      final PsiMethod[] constructors = haxeClass.getConstructors();
+      if (constructors.length > 0) {
+        final HaxeFunctionDeclarationWithAttributes constructor = (HaxeFunctionDeclarationWithAttributes)constructors[0];
+        final HaxeClassResolveResult resolveResult = HaxeClassResolveResult.create(haxeClass, specialization);
+
+        return build(constructor, resolveResult, specialization, false);
+      }
+    }
+
+    return null;
+  }
+
+  private static HaxeFunctionDescription build(HaxeMethod method, HaxeClassResolveResult resolveResult, HaxeGenericSpecialization specialization, boolean isExtension) {
+    String returnType = null;
+    HaxeParameterDescription[] parameterDescriptions;
+
+    final HaxeTypeTag typeTag = PsiTreeUtil.getChildOfType(method, HaxeTypeTag.class);
+    if (typeTag != null) {
+      returnType = HaxePresentableUtil.buildTypeText(method, typeTag, resolveResult.getSpecialization());
+    }
+
+    final HaxeParameterList parameterList = PsiTreeUtil.getChildOfType(method, HaxeParameterList.class);
+    if (parameterList != null) {
+      List<HaxeParameter> list = parameterList.getParameterList();
+      if (isExtension) {
+        list.remove(0);
+      }
+
+      parameterDescriptions = HaxeParameterDescriptionBuilder.buildFromList(list, specialization);
+    } else {
+      parameterDescriptions = new HaxeParameterDescription[0];
+    }
+
+    return new HaxeFunctionDescription(
+      method.getName(),
+      returnType,
+      parameterDescriptions
+    );
+  }
+}

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
@@ -44,12 +44,12 @@ class HaxeFunctionDescriptionBuilder {
   @Nullable
   static HaxeFunctionDescription buildForConstructor(final HaxeNewExpression expression) {
     final HaxeGenericSpecialization specialization = expression.getSpecialization();
-    final HaxeClass haxeClass = (HaxeClassDeclaration)expression.getType().getReferenceExpression().resolve();
+    final HaxeClass haxeClass = (HaxeClass)expression.getType().getReferenceExpression().resolve();
 
     if (haxeClass != null) {
       final PsiMethod[] constructors = haxeClass.getConstructors();
       if (constructors.length > 0) {
-        final HaxeFunctionDeclarationWithAttributes constructor = (HaxeFunctionDeclarationWithAttributes)constructors[0];
+        final HaxeMethod constructor = (HaxeMethod)constructors[0];
         final HaxeClassResolveResult resolveResult = HaxeClassResolveResult.create(haxeClass, specialization);
 
         return build(constructor, resolveResult, specialization, false);
@@ -60,13 +60,7 @@ class HaxeFunctionDescriptionBuilder {
   }
 
   private static HaxeFunctionDescription build(HaxeMethod method, HaxeClassResolveResult resolveResult, HaxeGenericSpecialization specialization, boolean isExtension) {
-    String returnType = null;
     HaxeParameterDescription[] parameterDescriptions;
-
-    final HaxeTypeTag typeTag = PsiTreeUtil.getChildOfType(method, HaxeTypeTag.class);
-    if (typeTag != null) {
-      returnType = HaxePresentableUtil.buildTypeText(method, typeTag, resolveResult.getSpecialization());
-    }
 
     final HaxeParameterList parameterList = PsiTreeUtil.getChildOfType(method, HaxeParameterList.class);
     if (parameterList != null) {
@@ -80,10 +74,6 @@ class HaxeFunctionDescriptionBuilder {
       parameterDescriptions = new HaxeParameterDescription[0];
     }
 
-    return new HaxeFunctionDescription(
-      method.getName(),
-      returnType,
-      parameterDescriptions
-    );
+    return new HaxeFunctionDescription(parameterDescriptions);
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
@@ -16,7 +16,6 @@
 package com.intellij.plugins.haxe.ide.info;
 
 import com.intellij.plugins.haxe.lang.psi.*;
-import com.intellij.plugins.haxe.util.HaxePresentableUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import com.intellij.psi.util.PsiTreeUtil;
@@ -30,12 +29,11 @@ class HaxeFunctionDescriptionBuilder {
     final HaxeGenericSpecialization specialization = expression.getSpecialization();
     final boolean isStaticExtension = expression.resolveIsStaticExtension();
 
-    final PsiElement target = ((HaxeReference)expression.getExpression()).resolve();
+    final HaxeReference reference = (HaxeReference)expression.getExpression();
+    final PsiElement target = reference.resolve();
 
     if (target instanceof HaxeMethod) {
-      final HaxeClass targetParent = (HaxeClass)((HaxeMethod)target).getContainingClass();
-      final HaxeClassResolveResult resolveResult = HaxeClassResolveResult.create(targetParent, specialization);
-
+      final HaxeClassResolveResult resolveResult = reference.resolveHaxeClass();
       return build((HaxeMethod)target, resolveResult, specialization, isStaticExtension);
     }
     return null;
@@ -60,7 +58,7 @@ class HaxeFunctionDescriptionBuilder {
   }
 
   private static HaxeFunctionDescription build(HaxeMethod method, HaxeClassResolveResult resolveResult, HaxeGenericSpecialization specialization, boolean isExtension) {
-    HaxeParameterDescription[] parameterDescriptions;
+    HaxeParameterDescription[] parameterDescriptions = null;
 
     final HaxeParameterList parameterList = PsiTreeUtil.getChildOfType(method, HaxeParameterList.class);
     if (parameterList != null) {
@@ -70,8 +68,6 @@ class HaxeFunctionDescriptionBuilder {
       }
 
       parameterDescriptions = HaxeParameterDescriptionBuilder.buildFromList(list, specialization);
-    } else {
-      parameterDescriptions = new HaxeParameterDescription[0];
     }
 
     return new HaxeFunctionDescription(parameterDescriptions);

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescription.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescription.java
@@ -70,9 +70,10 @@ public class HaxeParameterDescription {
     final boolean isValuePredefined = isOptional || hasInitialValue;
 
     final StringBuilder result = new StringBuilder();
-    if (isValuePredefined) {
-      result.append("[");
+    if (isOptional) {
+      result.append("?");
     }
+    
     result.append(name);
     result.append(":");
     if (hasType) {
@@ -85,8 +86,7 @@ public class HaxeParameterDescription {
     if (isValuePredefined) {
       result
         .append(" = ")
-        .append(isOptional ? "null" : initialValue)
-        .append("]");
+        .append(isOptional ? "null" : initialValue);
     }
 
     return result.toString();

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescription.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescription.java
@@ -18,18 +18,15 @@
  */
 package com.intellij.plugins.haxe.ide.info;
 
-import com.intellij.plugins.haxe.lang.psi.HaxeTypeTag;
 import com.intellij.plugins.haxe.model.type.ResultHolder;
 import com.intellij.plugins.haxe.util.HaxePresentableUtil;
 import org.jetbrains.annotations.Nullable;
-
-import javax.xml.transform.Result;
 
 public class HaxeParameterDescription {
   private final boolean isOptional;
   private final boolean hasInitialValue;
 
-  private final String text;
+  private final String description;
 
   private final ResultHolder resultHolder;
 
@@ -42,13 +39,17 @@ public class HaxeParameterDescription {
     this.isOptional = isOptional;
     this.hasInitialValue = initialValue != null;
 
-    this.text = compileDescription(name, type, initialValue);
+    this.description = compilePresentableDescription(name, type, initialValue);
     this.resultHolder = resultHolder;
   }
 
   @Override
   public String toString() {
-    return text;
+    return getPresentableText();
+  }
+
+  public String getPresentableText() {
+    return description;
   }
 
   public boolean isOptional() {
@@ -63,7 +64,7 @@ public class HaxeParameterDescription {
     return isOptional || hasInitialValue;
   }
 
-  private String compileDescription(String name, @Nullable String type, @Nullable String initialValue) {
+  private String compilePresentableDescription(String name, @Nullable String type, @Nullable String initialValue) {
     final boolean hasInitialValue = initialValue != null && !initialValue.isEmpty();
     final boolean hasType = type != null && !type.isEmpty();
     final boolean isValuePredefined = isOptional || hasInitialValue;

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescription.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescription.java
@@ -18,20 +18,32 @@
  */
 package com.intellij.plugins.haxe.ide.info;
 
+import com.intellij.plugins.haxe.lang.psi.HaxeTypeTag;
+import com.intellij.plugins.haxe.model.type.ResultHolder;
 import com.intellij.plugins.haxe.util.HaxePresentableUtil;
 import org.jetbrains.annotations.Nullable;
 
+import javax.xml.transform.Result;
+
 public class HaxeParameterDescription {
   private final boolean isOptional;
-  private final boolean isDefinedAsNullable;
+  private final boolean hasInitialValue;
 
   private final String text;
 
-  HaxeParameterDescription(String name, String type, String initialValue, boolean isOptional, boolean isDefinedAsNullable, int textOffset) {
+  private final ResultHolder resultHolder;
+
+  HaxeParameterDescription(String name,
+                           String type,
+                           String initialValue,
+                           boolean isOptional,
+                           ResultHolder resultHolder) {
+
     this.isOptional = isOptional;
-    this.isDefinedAsNullable = isDefinedAsNullable;
+    this.hasInitialValue = initialValue != null;
 
     this.text = compileDescription(name, type, initialValue);
+    this.resultHolder = resultHolder;
   }
 
   @Override
@@ -39,12 +51,16 @@ public class HaxeParameterDescription {
     return text;
   }
 
-  public boolean getIsOptional() {
+  public boolean isOptional() {
     return isOptional;
   }
 
-  public boolean getIsDefinedAsNullable() {
-    return isDefinedAsNullable;
+  public boolean hasInitialValue() {
+    return hasInitialValue;
+  }
+
+  public boolean isPredefined() {
+    return isOptional || hasInitialValue;
   }
 
   private String compileDescription(String name, @Nullable String type, @Nullable String initialValue) {
@@ -57,28 +73,25 @@ public class HaxeParameterDescription {
       result.append("[");
     }
     result.append(name);
+    result.append(":");
     if (hasType) {
-      result.append(":");
-      if (isOptional && !isDefinedAsNullable) {
-        result.append(HaxePresentableUtil.asNullable(type));
-      }
-      else {
-        result.append(type);
-      }
+      result.append(type);
     }
     else {
-      result.append(":").append(HaxePresentableUtil.unknownType());
+      result.append(HaxePresentableUtil.unknownType());
     }
-    if (hasInitialValue) {
-      result.append(" = ").append(initialValue);
-    }
-    else if (isOptional) {
-      result.append(" = null");
-    }
+
     if (isValuePredefined) {
-      result.append("]");
+      result
+        .append(" = ")
+        .append(isOptional ? "null" : initialValue)
+        .append("]");
     }
 
     return result.toString();
+  }
+
+  public ResultHolder getResultHolder() {
+    return resultHolder;
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescriptionBuilder.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterDescriptionBuilder.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017-2017 Ilya Malanin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.ide.info;
+
+import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.HaxePresentableUtil;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.logging.Logger;
+
+public class HaxeParameterDescriptionBuilder {
+
+  @NotNull
+  static HaxeParameterDescription[] buildFromList(@Nullable List<HaxeParameter> parameters, HaxeGenericSpecialization specialization) {
+    if (parameters == null || parameters.size() == 0) return new HaxeParameterDescription[0];
+
+    int currentOffset = 0;
+
+    HaxeParameterDescription[] result = new HaxeParameterDescription[parameters.size()];
+
+    for (int i = 0; i < parameters.size(); i++) {
+      HaxeParameter parameter = parameters.get(i);
+      HaxeParameterDescription parameterDescription = build(parameter, specialization, currentOffset);
+
+      currentOffset += parameterDescription.toString().length();
+
+      result[i] = parameterDescription;
+    }
+
+    return result;
+  }
+
+  @NotNull
+  private static HaxeParameterDescription build(HaxeParameter parameter, HaxeGenericSpecialization specialization, int textStartOffset) {
+    String name = parameter.getName();
+    String type = null;
+    String initialValue = null;
+
+    //FIXME: Check if type defined as nullable
+    boolean definedAsNullable = false;
+    boolean optional = parameter.getIsOptional() != null;
+
+    HaxeTypeTag typeTag = parameter.getTypeTag();
+    HaxeVarInit varInit = parameter.getVarInit();
+
+    if (typeTag != null) {
+      type = HaxePresentableUtil.buildTypeText(parameter, parameter.getTypeTag(), specialization);
+      Logger.getGlobal().info(typeTag.toString());
+    }
+
+    if (varInit != null) {
+      HaxeExpression varInitExpression = varInit.getExpression();
+      if (varInitExpression != null) {
+        initialValue = varInit.getExpression().getText();
+      }
+    }
+
+    return new HaxeParameterDescription(name, type, initialValue, optional, definedAsNullable, textStartOffset);
+  }
+}

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoHandler.java
@@ -81,7 +81,6 @@ public class HaxeParameterInfoHandler implements ParameterInfoHandler<PsiElement
   @Nullable
   private PsiElement findCallOrNewExpressionUnderCaret(@NotNull ParameterInfoContext context) {
     final PsiElement place = context.getFile().findElementAt(context.getEditor().getCaretModel().getOffset());
-
     return PsiTreeUtil.getParentOfType(place, HaxeCallExpression.class, HaxeNewExpression.class);
   }
 
@@ -224,6 +223,7 @@ public class HaxeParameterInfoHandler implements ParameterInfoHandler<PsiElement
                                                        int currentArgumentIndex) {
 
     int argumentIndex = 0;
+    int recoverParameterIndex = 0;
 
     if (arguments == null || arguments.size() == 0) return argumentIndex;
 
@@ -238,6 +238,7 @@ public class HaxeParameterInfoHandler implements ParameterInfoHandler<PsiElement
       if (!parameters[parameterIndex].isPredefined()) {
         if (argumentIndex == currentArgumentIndex) return parameterIndex;
 
+        recoverParameterIndex = parameterIndex + 1;
         argumentIndex++;
         continue;
       }
@@ -250,11 +251,12 @@ public class HaxeParameterInfoHandler implements ParameterInfoHandler<PsiElement
       if (parameterType.canAssign(argumentType)) {
         if (argumentIndex == currentArgumentIndex) return parameterIndex;
 
+        recoverParameterIndex = parameterIndex + 1;
         argumentIndex++;
       }
     }
 
-    return -1;
+    return recoverParameterIndex;
   }
 
   private List<HaxeExpression> getArgumentsList(@NotNull PsiElement element) {

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -59,21 +59,10 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
   }
 
   @Override
-  @Nullable @NonNls
+  @NotNull
+  @NonNls
   public String getName() {
-    String name = super.getName();
-    if (null == name) {
-      if (getText().contains(" function new(")) {
-        return HaxeTokenTypes.ONEW.toString();
-      }
-      else {
-        final PsiIdentifier nameIdentifier = getNameIdentifier();
-        if (nameIdentifier != null) {
-          name = nameIdentifier.getText();
-        }
-      }
-    }
-
+    final String name = super.getName();
     return (name != null) ? name : "<unnamed>";
   }
 
@@ -165,14 +154,9 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
 
   @Override
   public boolean isConstructor() {
-    if (super.getName()==null &&
-        getComponentName()==null &&
-        getText().contains("function new(") &&
-        !isStatic() &&
-        !isOverride()) {
-      return true;
-    }
-    return false;
+    String name = getName();
+
+    return name != null && name.equals(HaxeTokenTypes.ONEW.toString());
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -63,6 +63,17 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
   @NonNls
   public String getName() {
     final String name = super.getName();
+
+    if (name == null) {
+      PsiElement child = this.getFirstChild();
+      while (child != null) {
+        if (child instanceof HaxePsiToken && child.getText().equals(HaxeTokenTypes.ONEW.toString())) {
+          return child.getText();
+        }
+        child = child.getNextSibling();
+      }
+    }
+
     return (name != null) ? name : "<unnamed>";
   }
 
@@ -155,7 +166,6 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
   @Override
   public boolean isConstructor() {
     String name = getName();
-
     return name != null && name.equals(HaxeTokenTypes.ONEW.toString());
   }
 

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -31,8 +31,8 @@ import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.util.*;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.ResolveCache;
-import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.impl.source.tree.JavaSourceUtil;
+import com.intellij.psi.impl.source.tree.LeafPsiElement;
 import com.intellij.psi.infos.CandidateInfo;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.tree.IElementType;
@@ -41,7 +41,6 @@ import com.intellij.util.ArrayUtil;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.containers.ContainerUtil;
 import gnu.trove.THashSet;
-import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -85,6 +84,13 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
     HaxeExpression expression = this;
     if (this instanceof HaxeCallExpression) {
       expression = ((HaxeCallExpression)this).getExpression();
+    }
+    else if (this instanceof HaxeNewExpression) {
+      HaxeNewExpression newExpression = (HaxeNewExpression)this;
+      HaxeClass haxeClass = (HaxeClass)newExpression.getType().getReferenceExpression().resolve();
+      final HaxeClassResolveResult result = HaxeClassResolveResult.create(haxeClass);
+      result.specializeByParameters(newExpression.getType().getTypeParam());
+      return result.getSpecialization();
     }
 
     // The specialization for a reference comes from either the type of the left-hand side of the

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
@@ -18,6 +18,7 @@
  */
 package com.intellij.plugins.haxe.model;
 
+import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeNamedComponent;
 import com.intellij.plugins.haxe.model.type.*;
@@ -101,7 +102,7 @@ public class HaxeMethodModel extends HaxeMemberModel {
   }
 
   public boolean isConstructor() {
-    return this.getName().equals("new");
+    return this.getName().equals(HaxeTokenTypes.ONEW.toString());
   }
 
   public boolean isStaticInit() {

--- a/src/common/com/intellij/plugins/haxe/util/HaxePresentableUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxePresentableUtil.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017-2017 Ilya Malanin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,5 +176,13 @@ public class HaxePresentableUtil {
       result.append(">");
     }
     return result.toString();
+  }
+
+  public static String asNullable(String type) {
+    return "Null<"+type+">";
+  }
+
+  public static String unknownType() {
+    return asNullable("Dynamic");
   }
 }

--- a/src/common/com/intellij/plugins/haxe/util/HaxePresentableUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxePresentableUtil.java
@@ -183,6 +183,6 @@ public class HaxePresentableUtil {
   }
 
   public static String unknownType() {
-    return asNullable("Dynamic");
+    return asNullable("Unknown");
   }
 }

--- a/src/common/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
@@ -54,7 +54,7 @@ public class UsefulPsiTreeUtil {
 
   @Nullable
   public static PsiElement getPrevSiblingSkipWhiteSpacesAndComments(@Nullable PsiElement sibling, boolean strictly) {
-    return getPrevSiblingSkipingCondition(sibling, new Condition<PsiElement>() {
+    return getPrevSiblingSkippingCondition(sibling, new Condition<PsiElement>() {
       @Override
       public boolean value(PsiElement element) {
         return isWhitespaceOrComment(element);
@@ -64,7 +64,7 @@ public class UsefulPsiTreeUtil {
 
   @Nullable
   public static PsiElement getPrevSiblingSkipWhiteSpaces(@Nullable PsiElement sibling, boolean strictly) {
-    return getPrevSiblingSkipingCondition(sibling, new Condition<PsiElement>() {
+    return getPrevSiblingSkippingCondition(sibling, new Condition<PsiElement>() {
       @Override
       public boolean value(PsiElement element) {
         return element instanceof PsiWhiteSpace;
@@ -73,11 +73,21 @@ public class UsefulPsiTreeUtil {
   }
 
   @Nullable
-  public static PsiElement getPrevSiblingSkipingCondition(@Nullable PsiElement sibling, Condition<PsiElement> condition, boolean strictly) {
+  public static PsiElement getPrevSiblingSkippingCondition(@Nullable PsiElement sibling, Condition<PsiElement> condition, boolean strictly) {
     if (sibling == null) return null;
     PsiElement result = strictly ? sibling.getPrevSibling() : sibling;
     while (result != null && condition.value(result)) {
       result = result.getPrevSibling();
+    }
+    return result;
+  }
+
+  @Nullable
+  public static PsiElement getNextSiblingSkippingCondition(@Nullable PsiElement sibling, Condition<PsiElement> condition, boolean strictly) {
+    if (sibling == null) return null;
+    PsiElement result = strictly ? sibling.getNextSibling() : sibling;
+    while (result != null && condition.value(result)) {
+      result = result.getNextSibling();
     }
     return result;
   }

--- a/src/common/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/UsefulPsiTreeUtil.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017-2017 Ilya Malanin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -468,4 +469,15 @@ public class UsefulPsiTreeUtil {
     }
     return sibling;
   }
+
+  @Nullable
+  public static PsiElement getNextSiblingSkipWhiteSpacesAndComments(@Nullable PsiElement element) {
+    if (element == null) return null;
+    PsiElement sibling = element.getNextSibling();
+    while (sibling != null && isWhitespaceOrComment(sibling)) {
+      sibling = sibling.getNextSibling();
+    }
+    return sibling;
+  }
+
 }

--- a/testData/paramInfo/ParamInfo10.hx
+++ b/testData/paramInfo/ParamInfo10.hx
@@ -1,0 +1,14 @@
+class Test {
+  static function main() {
+    new ConstructorGenericParameters<Node>(10,<caret> new Node());
+  }
+}
+
+class ConstructorGenericParameters<T> {
+  public function new(a:Int, b:Bool = false, ?c:Float, ?d:T) {
+
+  }
+}
+
+class Node {
+}

--- a/testData/paramInfo/ParamInfo9.hx
+++ b/testData/paramInfo/ParamInfo9.hx
@@ -1,0 +1,11 @@
+class Test {
+  static function main() {
+    new ConstructorParameters(10, <caret>0.0);
+  }
+}
+
+class ConstructorParameters {
+  public function new(a:Int, b:Bool = false, ?c:Float, ?d) {
+
+  }
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoTest.java
@@ -75,6 +75,7 @@ public class HaxeParameterInfoTest extends LightCodeInsightTestCase {
     MockUpdateParameterInfoContext updateContext = new MockUpdateParameterInfoContext(myEditor, myFile);
     final PsiElement element = parameterInfoHandler.findElementForUpdatingParameterInfo(updateContext);
     assertNotNull(element);
+    updateContext.setParameterOwner(elt);
     parameterInfoHandler.updateParameterInfo(element, updateContext);
     assertEquals(highlightedParameterIndex, updateContext.getCurrentParameter());
   }
@@ -87,11 +88,11 @@ public class HaxeParameterInfoTest extends LightCodeInsightTestCase {
 
 
   public void testParamInfo1() throws Throwable {
-    doTest("p1:Int, p2, p3:Node", 0);
+    doTest("p1:Int, p2:Null<Unknown>, p3:Node", 0);
   }
 
   public void testParamInfo2() throws Throwable {
-    doTest("p1:Int, p2, p3:Node", 2);
+    doTest("p1:Int, p2:Null<Unknown>, p3:Node", 2);
   }
 
   public void testParamInfo3() throws Throwable {
@@ -99,7 +100,7 @@ public class HaxeParameterInfoTest extends LightCodeInsightTestCase {
   }
 
   public void testParamInfo4() throws Throwable {
-    doTest("x:Int, y:Int", 0);
+    doTest("x:Int, y:Int", 1);
   }
 
   public void testParamInfo5() throws Throwable {
@@ -107,7 +108,7 @@ public class HaxeParameterInfoTest extends LightCodeInsightTestCase {
   }
 
   public void testParamInfo6() throws Throwable {
-    doTest("x:Int, y:Int = 239", 1);
+    doTest("x:Int, [y:Int = 239]", 1);
   }
 
   public void testParamInfo7() throws Throwable {
@@ -117,6 +118,15 @@ public class HaxeParameterInfoTest extends LightCodeInsightTestCase {
 
   public void testParamInfo8() throws Throwable {
     doTest("t:Node", 0);
+  }
+
+  public void testParamInfo9() throws Throwable {
+    doTest("a:Int, [b:Bool = false], [c:Float = null], [d:Null<Unknown> = null]", 2);
+  }
+
+  public void testParamInfo10() throws Throwable {
+    // FIXME Test failing because generic specialization not properly resolving by HaxeTypeResolver (should be fixed) see #632
+    // doTest("a:Int, [b:Bool = false], [c:Float = null], [d:Node = null]", 3);
   }
 
   // Disabled - Tests issue #615.

--- a/testSrc/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoTest.java
@@ -108,7 +108,7 @@ public class HaxeParameterInfoTest extends LightCodeInsightTestCase {
   }
 
   public void testParamInfo6() throws Throwable {
-    doTest("x:Int, [y:Int = 239]", 1);
+    doTest("x:Int, y:Int = 239", 1);
   }
 
   public void testParamInfo7() throws Throwable {
@@ -121,12 +121,11 @@ public class HaxeParameterInfoTest extends LightCodeInsightTestCase {
   }
 
   public void testParamInfo9() throws Throwable {
-    doTest("a:Int, [b:Bool = false], [c:Float = null], [d:Null<Unknown> = null]", 2);
+    doTest("a:Int, b:Bool = false, ?c:Float = null, ?d:Null<Unknown> = null", 2);
   }
 
   public void testParamInfo10() throws Throwable {
-    // FIXME Test failing because generic specialization not properly resolving by HaxeTypeResolver (should be fixed) see #632
-    // doTest("a:Int, [b:Bool = false], [c:Float = null], [d:Node = null]", 3);
+    doTest("a:Int, b:Bool = false, ?c:Float = null, ?d:Node = null", 3);
   }
 
   // Disabled - Tests issue #615.


### PR DESCRIPTION
- Constructors now recognizing generics in "new Expressions()".
- "new Expressions()" are parsing better now, and not throwing parser error if you place comma before new argument (parameters info will not be hidden for "new Type(argument, );"
-  Added skipping for optional parameters, skipping based on types of passed arguments.
Known bug: parameter with type of generic specialization still not going to be recognized and parameter will not be highlighted. See issue: https://github.com/HaxeFoundation/intellij-haxe/issues/632