### PR TITLE
Remove the recursive nature of the arrow function parameter rules.

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -384,7 +384,8 @@ varInit ::= '=' expression {pin=1}
 parameter ::= '?'? componentName typeTag? varInit?
 {mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeParameterPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeParameterPsiMixin"}
 
-openParameterList ::= parameter {extends=parameterList}
+// An open parameter can't have all of the type and init info.  Plus, it makes the parser *very* *very* slow in some circumstances.
+openParameterList ::= componentName {extends=parameterList}
 private parenthesizedParameterList ::= '(' parameterList ')'
 parameterList ::= (parameter (',' parameter)*)? {recoverWhile="parameterListRecovery" mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeParameterListPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeParameterListPsiMixin"}
 private parameterListRecovery ::= !('(' | ')')  // Open parens are allowable in arrow function arguments.

--- a/src/common/com/intellij/plugins/haxe/lang/parser/HaxeParserDefinition.java
+++ b/src/common/com/intellij/plugins/haxe/lang/parser/HaxeParserDefinition.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@ package com.intellij.plugins.haxe.lang.parser;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.ParserDefinition;
+import com.intellij.lang.PsiBuilder;
 import com.intellij.lang.PsiParser;
 import com.intellij.lexer.Lexer;
 import com.intellij.openapi.project.Project;
@@ -26,21 +28,51 @@ import com.intellij.plugins.haxe.lang.lexer.HaxeLexer;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypeSets;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.HaxeFile;
+import com.intellij.plugins.haxe.util.HaxeDebugTimeLog;
 import com.intellij.psi.FileViewProvider;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.impl.source.resolve.FileContextUtil;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.tree.IFileElementType;
 import com.intellij.psi.tree.TokenSet;
 import org.jetbrains.annotations.NotNull;
 
 public class HaxeParserDefinition implements ParserDefinition {
+  /** Set this false when you're finished debugging. */
+  private static boolean debugging = false;
+
+  public static class HaxeParserWrapper extends HaxeParser {
+    @Override
+    public ASTNode parse(IElementType t, PsiBuilder b) {
+      if (debugging) {
+        HaxeDebugTimeLog timeLog = null;
+
+        // The file is attached to the user data. :/  I suspect this was a hack, but it's what we've got available.
+        PsiFile file = b.getUserDataUnprotected(FileContextUtil.CONTAINING_FILE_KEY);
+
+        String description = null != file ? file.getName() : t.toString();
+        timeLog = HaxeDebugTimeLog.startNew("HaxeParser " + description, HaxeDebugTimeLog.Since.StartAndPrevious);
+
+        ASTNode node = super.parse(t, b);
+
+        timeLog.stamp("Finished parsing.");
+        timeLog.printIfTimeExceeds(20 /* milliseconds */);
+
+        return node;
+      }
+      return super.parse(t,b);
+    }
+  }
+
+
   @NotNull
   public Lexer createLexer(Project project) {
     return new HaxeLexer(project);
   }
 
   public PsiParser createParser(Project project) {
-    return new HaxeParser();
+    return new HaxeParserWrapper();
   }
 
   public IFileElementType getFileNodeType() {


### PR DESCRIPTION
Bare parameters can only be names, and cannot be full parameter definitions. (Full definitions must be in parens, anyway.)