### PR TITLE
Address freezes and overflows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ env:
     - IDEA_VERSION=14.1.7 ANT_TARGET=test
     - IDEA_VERSION=15.0.6 ANT_TARGET=compile_test
     - IDEA_VERSION=2016.3.7 ANT_TARGET=test
-    - IDEA_VERSION=2017.1.3 ANT_TARGET=test
+    - IDEA_VERSION=2017.1.5 ANT_TARGET=test
+    - IDEA_VERSION=2017.2 ANT_TARGET=test
 
 notifications:
   email: false

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -285,6 +286,11 @@ public class HaxelibProjectUpdater  {
         return true;
       }
     });
+
+    // Remove anything that appears in both lists (because it's already there).
+    HaxeClasspath originalRemove = new HaxeClasspath(toRemove);
+    toRemove.removeAll(toAdd);
+    toAdd.removeAll(originalRemove);
 
     updateModule(module, toRemove, toAdd);
   }

--- a/src/common/com/intellij/plugins/haxe/ide/HaxeFindUsagesProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeFindUsagesProvider.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +43,6 @@ public class HaxeFindUsagesProvider implements FindUsagesProvider {
     }
   }
 
-
   @Override
   public WordsScanner getWordsScanner() {
     return null;
@@ -55,7 +55,9 @@ public class HaxeFindUsagesProvider implements FindUsagesProvider {
     if (null != parent) {
       ret = true;
     }
-    LOG.debug("canFindUsagesFor("+psiElement.toString()+")->"+(ret?"true":"false"));
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("canFindUsagesFor(" + debugId(psiElement) + ")->" + (ret ? "true" : "false"));
+    }
     return ret;
   }
 
@@ -70,7 +72,9 @@ public class HaxeFindUsagesProvider implements FindUsagesProvider {
     if (null == result) {
       result = "reference";
     }
-    LOG.debug("getType("+element.toString()+")->"+result);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("getType(" + debugId(element) + ")->" + result);
+    }
     return result;
   }
 
@@ -109,4 +113,20 @@ public class HaxeFindUsagesProvider implements FindUsagesProvider {
     PsiElement parent = PsiTreeUtil.getParentOfType(psiElement, HaxeNamedComponent.class, false);
     return parent;
   }
+
+  /**
+   * Get a useful debug value from an element.
+   * XXX: Should check whether element is a HaxePsiElement type and call a specific debug method there?
+   *
+   * @param psiElement
+   * @return ID for debug logging.
+   */
+  private static String debugId(final PsiElement psiElement) {
+    String s = psiElement.toString();
+    if (s.length() > DEBUG_ID_LEN) {
+      s = s.substring(0, DEBUG_ID_LEN);
+    }
+    return s.replaceAll("\n", " ");
+  }
+  private static final int DEBUG_ID_LEN = 80;
 }

--- a/src/common/com/intellij/plugins/haxe/ide/index/HaxeComponentFileNameIndex.java
+++ b/src/common/com/intellij/plugins/haxe/ide/index/HaxeComponentFileNameIndex.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +46,9 @@ public class HaxeComponentFileNameIndex extends ScalarIndexExtension<String> {
   private static final int INDEX_VERSION = HaxeIndexUtil.BASE_INDEX_VERSION + 4;
   private DataIndexer<String, Void, FileContent> myDataIndexer = new MyDataIndexer();
 
+  /** The list of files searched in dumb mode.  (Always empty.) */
+  public static List<VirtualFile> DUMB_MODE_LIST = new ArrayList<VirtualFile>();
+
   @NotNull
   @Override
   public ID<String, Void> getName() {
@@ -79,6 +83,14 @@ public class HaxeComponentFileNameIndex extends ScalarIndexExtension<String> {
 
   @NotNull
   public static List<VirtualFile> getFilesNameByQName(@NotNull String qName, @NotNull final GlobalSearchScope filter) {
+
+    Project project = filter.getProject();
+    if (project != null) {
+      if (DumbService.isDumb(project)) {
+        return DUMB_MODE_LIST;
+      }
+    }
+
     final List<VirtualFile> result = new ArrayList<VirtualFile>();
     getFileNames(qName, new Processor<VirtualFile>() {
       @Override
@@ -90,7 +102,7 @@ public class HaxeComponentFileNameIndex extends ScalarIndexExtension<String> {
     return result;
   }
 
-  public static boolean getFileNames(@NotNull String qName,
+  private static boolean getFileNames(@NotNull String qName,
                                      @NotNull Processor<VirtualFile> processor,
                                      @NotNull final GlobalSearchScope filter) {
     Project project = filter.getProject();

--- a/src/common/com/intellij/plugins/haxe/ide/index/HaxeComponentIndex.java
+++ b/src/common/com/intellij/plugins/haxe/ide/index/HaxeComponentIndex.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -85,6 +86,7 @@ public class HaxeComponentIndex extends FileBasedIndexExtension<String, HaxeClas
   }
 
   public static List<HaxeComponent> getItemsByName(String name, Project project, GlobalSearchScope searchScope) {
+    HaxeIndexUtil.warnIfDumbMode(project);
     Collection<VirtualFile> files =
       FileBasedIndex.getInstance().getContainingFiles(HAXE_COMPONENT_INDEX, name, searchScope);
     final List<HaxeComponent> result = new ArrayList<HaxeComponent>();
@@ -102,6 +104,7 @@ public class HaxeComponentIndex extends FileBasedIndexExtension<String, HaxeClas
   }
 
   public static void processAll(Project project, Processor<Pair<String, HaxeClassInfo>> processor, GlobalSearchScope scope) {
+    HaxeIndexUtil.warnIfDumbMode(project);
     final Collection<String> keys = getNames(project);
     for (String key : keys) {
       final List<HaxeClassInfo> values = FileBasedIndex.getInstance().getValues(HAXE_COMPONENT_INDEX, key, scope);
@@ -115,6 +118,7 @@ public class HaxeComponentIndex extends FileBasedIndexExtension<String, HaxeClas
   }
 
   public static Collection<String> getNames(Project project) {
+    HaxeIndexUtil.warnIfDumbMode(project);
     return FileBasedIndex.getInstance().getAllKeys(HAXE_COMPONENT_INDEX, project);
   }
 

--- a/src/common/com/intellij/plugins/haxe/ide/index/HaxeIndexUtil.java
+++ b/src/common/com/intellij/plugins/haxe/ide/index/HaxeIndexUtil.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +18,32 @@
  */
 package com.intellij.plugins.haxe.ide.index;
 
+import com.intellij.openapi.project.DumbService;
+import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
+import com.intellij.plugins.haxe.util.HaxeDebugUtil;
+import org.apache.log4j.Level;
+
 /**
  * Created by fedorkorotkov.
  */
 public class HaxeIndexUtil {
   public static int BASE_INDEX_VERSION = 1;
+
+  public static final HaxeDebugLogger LOG = HaxeDebugLogger.getLogger();
+  static {
+    // Logs can be turned on externally (and before they're allocated!).  Make sure that
+    // our warnings still get out.
+    if (!LOG.isEnabledFor(Level.WARN)) {
+      LOG.setLevel(Level.WARN);
+    }
+  }
+
+  public static boolean warnIfDumbMode(Project project) {
+    if (DumbService.isDumb(project)) {
+      LOG.warn("Unexpected index activity while in dumb mode at " + HaxeDebugUtil.printCallers(1));
+      return false;
+    }
+    return true;
+  }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/index/HaxeSymbolIndex.java
+++ b/src/common/com/intellij/plugins/haxe/ide/index/HaxeSymbolIndex.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2016 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2017 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +81,7 @@ public class HaxeSymbolIndex extends ScalarIndexExtension<String> {
   }
 
   public static String[] getAllSymbols(@NotNull final GlobalSearchScope scope) {
+    HaxeIndexUtil.warnIfDumbMode(scope.getProject());
     final CommonProcessors.CollectProcessor<String> processor = new CommonProcessors.CollectProcessor<String>();
     FileBasedIndex.getInstance().processAllKeys(HAXE_SYMBOL_INDEX, processor, scope, null);
     return ArrayUtil.toStringArray(processor.getResults());
@@ -88,6 +90,7 @@ public class HaxeSymbolIndex extends ScalarIndexExtension<String> {
   public static List<HaxeComponentName> getItemsByName(@NotNull final String name,
                                                        @NotNull final Project project,
                                                        @NotNull final GlobalSearchScope searchScope) {
+    HaxeIndexUtil.warnIfDumbMode(project);
     final Collection<VirtualFile> files =
       FileBasedIndex.getInstance().getContainingFiles(HAXE_SYMBOL_INDEX, name, searchScope);
     final Set<HaxeComponentName> result = new THashSet<HaxeComponentName>();

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -20,6 +20,7 @@ package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.util.io.FileUtil;
@@ -181,7 +182,12 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
     //
 
     // For the moment (while debugging the resolver) let's do this without caching.
-    boolean skipCaching = false;
+    boolean skipCachingForDebug = false;
+
+    // If we are in dumb mode (e.g. we are still indexing files and resolving may
+    // fail until the indices are complete), we don't want to cache the (likely incorrect)
+    // results.
+    boolean skipCaching = skipCachingForDebug || DumbService.isDumb(getProject());
     List<? extends PsiElement> cachedNames
               = skipCaching ? (HaxeResolver.INSTANCE).resolve(this, incompleteCode)
                             : ResolveCache.getInstance(getProject()).resolveWithCaching(this, HaxeResolver.INSTANCE, true, incompleteCode);


### PR DESCRIPTION
Attempt to fix freezes in IDEA17 by eliminating a stack overflow during resolution, and by disallowing access to indices until indexing is complete.