### PR TITLE
Symlink fix for classpaths

### DIFF
--- a/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/14.1/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -55,6 +55,7 @@ import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
 import com.intellij.plugins.haxe.runner.HaxeApplicationConfiguration;
 import com.intellij.plugins.haxe.runner.NMERunningState;
 import com.intellij.plugins.haxe.runner.OpenFLRunningState;
+import com.intellij.plugins.haxe.util.HaxeFileUtil;
 import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
@@ -63,6 +64,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.ui.ColoredTextContainer;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.concurrency.QueueProcessor;
+import com.intellij.util.io.URLUtil;
 import com.intellij.util.ui.MessageCategory;
 import com.intellij.xdebugger.*;
 import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
@@ -794,70 +796,73 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
         mClassAndFunctionName =
           ((String)frameList.params.__a[2] + "." +
            (String)frameList.params.__a[3]);
-        VirtualFile file = null;
 
-        //String fileName = VfsUtil.extractFileName(mFileName);
-        //if (fileName == null) {
-        //  fileName = mFileName;
-        //}
+        VirtualFileManager vfm = VirtualFileManager.getInstance();
+        VirtualFile file = vfm.findFileByUrl(vfm.constructUrl(URLUtil.FILE_PROTOCOL, mFileName));
+        if (null == file || !file.exists()) {
 
-        final String fileNameToLookFor = mFileName; // fileName
-        final java.util.Collection<VirtualFile> files =
-          ApplicationManager.getApplication().runReadAction(
-            new Computable<java.util.Collection<VirtualFile>>() {
-              @Override
-              public java.util.Collection<VirtualFile> compute() {
+          // Filename index can only deal with the name, not any paths.
+          String fileName = VfsUtil.extractFileName(mFileName);
+          if (fileName == null) {
+            fileName = mFileName;
+          }
 
-                java.util.Collection<VirtualFile> files =
-                  FilenameIndex.getVirtualFilesByName(
-                    project, fileNameToLookFor, GlobalSearchScope.moduleScope(module));
-                if (files.isEmpty()) {
-                  files = FilenameIndex.getVirtualFilesByName(
-                    project, fileNameToLookFor, GlobalSearchScope.allScope(project));
+          final String fileNameToLookFor = fileName;
+          final java.util.Collection<VirtualFile> files =
+            ApplicationManager.getApplication().runReadAction(
+              new Computable<java.util.Collection<VirtualFile>>() {
+                @Override
+                public java.util.Collection<VirtualFile> compute() {
+
+                  java.util.Collection<VirtualFile> files =
+                    FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.moduleScope(module));
+                  if (files.isEmpty()) {
+                    files = FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.moduleWithDependenciesScope(module));
+                  }
+                  if (files.isEmpty()) {
+                    files = FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.moduleWithLibrariesScope(module));
+                  }
+                  if (files.isEmpty()) {
+                    files = FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.allScope(project));
+                  }
+                  return files;
                 }
-                return files;
+              }
+            );
+
+          java.util.Collection<VirtualFile> matches = new THashSet<VirtualFile>();
+          if (!files.isEmpty()) {
+            for (VirtualFile f : files) {
+              if (f.getPath().endsWith(mFileName)) {
+                matches.add(f);
               }
             }
-          );
-
-        java.util.Collection<VirtualFile> matches = new THashSet<VirtualFile>();
-        if (!files.isEmpty()) {
-          for (VirtualFile f : files) {
-            if (f.getPath().endsWith(mFileName)) {
-              matches.add(f);
-            }
           }
-        }
-        if (matches.isEmpty()) {
-          // If we don't have a match yet, then walk the classpath looking for
-          // an appropriate file.
-          file = HaxelibClasspathUtils.findFileOnClasspath(module, mFileName);
-        } else if (matches.size() == 1) {
-          // Got one.  If it's a good file, keep it.  Otherwise, try to pick it
-          // out of the classpath.
-          VirtualFile possible = matches.iterator().next();
-          file = possible.isValid() ? possible : HaxelibClasspathUtils.findFileOnClasspath(module, possible.toString());
-        } else {
-          // Too many matches. Get the first that occurs on the classpath.
-          file = HaxelibClasspathUtils.findFirstFileOnClasspath(module, matches);
+          if (matches.isEmpty()) {
+            // If we don't have a match yet, then walk the classpath looking for
+            // an appropriate file.
+            file = HaxelibClasspathUtils.findFileOnClasspath(module, mFileName);
+          }
+          else if (matches.size() == 1) {
+            // Got one.  If it's a good file, keep it.  Otherwise, try to pick it
+            // out of the classpath.
+            VirtualFile possible = matches.iterator().next();
+            file = possible.isValid() ? possible : HaxelibClasspathUtils.findFileOnClasspath(module, possible.toString());
+          }
+          else {
+            // Too many matches. Get the first that occurs on the classpath.
+            file = HaxelibClasspathUtils.findFirstFileOnClasspath(module, matches);
+          }
         }
 
         // Now, work around the fact that IDEA treats symlinks as separate files.
         // XXX: This should be controlled via an UI option.
-        if (null != file) { // && file.is(VFileProperty.SYMLINK)) {
-          // file.getnCanonicalFile() only works if the file is a symlink.  It ignores symlinks
-          // in the path.
-          // file = file.getCanonicalFile();
-          java.io.File f = new java.io.File(file.getPath());
-          java.io.File absolute = null == f ? null : f.getAbsoluteFile();
-          if ( null != absolute ) {
-            // Of course, IDEA's notion of a URI requires "://" after the protocol separator
-            // (as opposed to Java's ":").  So we can't just use the Java URI.
-            VirtualFileManager vfm = VirtualFileManager.getInstance();
-            String canonicalUri = absolute.toURI().toString();
-            String ideaUri = vfm.constructUrl(absolute.toURI().getScheme(), absolute.getPath());
-            file = VirtualFileManager.getInstance().findFileByUrl(ideaUri);
-          }
+        if (null != file) {
+          file = HaxeFileUtil.getCanonicalFile(file);
         }
 
         mSourcePosition =

--- a/src/16.0/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
+++ b/src/16.0/com/intellij/plugins/haxe/runner/debugger/HaxeDebugRunner.java
@@ -42,7 +42,6 @@ import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.text.StringUtil;
-import com.intellij.openapi.vfs.VFileProperty;
 import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -56,6 +55,7 @@ import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
 import com.intellij.plugins.haxe.runner.HaxeApplicationConfiguration;
 import com.intellij.plugins.haxe.runner.NMERunningState;
 import com.intellij.plugins.haxe.runner.OpenFLRunningState;
+import com.intellij.plugins.haxe.util.HaxeFileUtil;
 import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
@@ -64,6 +64,7 @@ import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.ui.ColoredTextContainer;
 import com.intellij.ui.SimpleTextAttributes;
 import com.intellij.util.concurrency.QueueProcessor;
+import com.intellij.util.io.URLUtil;
 import com.intellij.util.ui.MessageCategory;
 import com.intellij.xdebugger.*;
 import com.intellij.xdebugger.breakpoints.XBreakpointHandler;
@@ -803,70 +804,73 @@ public class HaxeDebugRunner extends DefaultProgramRunner {
         mClassAndFunctionName =
           ((String)frameList.params.__a[2] + "." +
            (String)frameList.params.__a[3]);
-        VirtualFile file = null;
 
-        String fileName = VfsUtil.extractFileName(mFileName);
-        if (fileName == null) {
-          fileName = mFileName;
-        }
+        VirtualFileManager vfm = VirtualFileManager.getInstance();
+        VirtualFile file = vfm.findFileByUrl(vfm.constructUrl(URLUtil.FILE_PROTOCOL, mFileName));
+        if (null == file || !file.exists()) {
 
-        final String fileNameToLookFor = fileName;
-        final java.util.Collection<VirtualFile> files =
-          ApplicationManager.getApplication().runReadAction(
-            new Computable<java.util.Collection<VirtualFile>>() {
-              @Override
-              public java.util.Collection<VirtualFile> compute() {
+          // Filename index can only deal with the name, not any paths.
+          String fileName = VfsUtil.extractFileName(mFileName);
+          if (fileName == null) {
+            fileName = mFileName;
+          }
 
-                java.util.Collection<VirtualFile> files =
-                  FilenameIndex.getVirtualFilesByName(
-                    project, fileNameToLookFor, GlobalSearchScope.moduleScope(module));
-                if (files.isEmpty()) {
-                  files = FilenameIndex.getVirtualFilesByName(
-                    project, fileNameToLookFor, GlobalSearchScope.allScope(project));
+          final String fileNameToLookFor = fileName;
+          final java.util.Collection<VirtualFile> files =
+            ApplicationManager.getApplication().runReadAction(
+              new Computable<java.util.Collection<VirtualFile>>() {
+                @Override
+                public java.util.Collection<VirtualFile> compute() {
+
+                  java.util.Collection<VirtualFile> files =
+                    FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.moduleScope(module));
+                  if (files.isEmpty()) {
+                    files = FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.moduleWithDependenciesScope(module));
+                  }
+                  if (files.isEmpty()) {
+                    files = FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.moduleWithLibrariesScope(module));
+                  }
+                  if (files.isEmpty()) {
+                    files = FilenameIndex.getVirtualFilesByName(
+                      project, fileNameToLookFor, GlobalSearchScope.allScope(project));
+                  }
+                  return files;
                 }
-                return files;
+              }
+            );
+
+          java.util.Collection<VirtualFile> matches = new THashSet<VirtualFile>();
+          if (!files.isEmpty()) {
+            for (VirtualFile f : files) {
+              if (f.getPath().endsWith(mFileName)) {
+                matches.add(f);
               }
             }
-          );
-
-        java.util.Collection<VirtualFile> matches = new THashSet<VirtualFile>();
-        if (!files.isEmpty()) {
-          for (VirtualFile f : files) {
-            if (f.getPath().endsWith(mFileName)) {
-              matches.add(f);
-            }
           }
-        }
-        if (matches.isEmpty()) {
-          // If we don't have a match yet, then walk the classpath looking for
-          // an appropriate file.
-          file = HaxelibClasspathUtils.findFileOnClasspath(module, mFileName);
-        } else if (matches.size() == 1) {
-          // Got one.  If it's a good file, keep it.  Otherwise, try to pick it
-          // out of the classpath.
-          VirtualFile possible = matches.iterator().next();
-          file = possible.isValid() ? possible : HaxelibClasspathUtils.findFileOnClasspath(module, possible.toString());
-        } else {
-          // Too many matches. Get the first that occurs on the classpath.
-          file = HaxelibClasspathUtils.findFirstFileOnClasspath(module, matches);
+          if (matches.isEmpty()) {
+            // If we don't have a match yet, then walk the classpath looking for
+            // an appropriate file.
+            file = HaxelibClasspathUtils.findFileOnClasspath(module, mFileName);
+          }
+          else if (matches.size() == 1) {
+            // Got one.  If it's a good file, keep it.  Otherwise, try to pick it
+            // out of the classpath.
+            VirtualFile possible = matches.iterator().next();
+            file = possible.isValid() ? possible : HaxelibClasspathUtils.findFileOnClasspath(module, possible.toString());
+          }
+          else {
+            // Too many matches. Get the first that occurs on the classpath.
+            file = HaxelibClasspathUtils.findFirstFileOnClasspath(module, matches);
+          }
         }
 
         // Now, work around the fact that IDEA treats symlinks as separate files.
         // XXX: This should be controlled via an UI option.
-        if (null != file) { // && file.is(VFileProperty.SYMLINK)) {
-          // file.getnCanonicalFile() only works if the file is a symlink.  It ignores symlinks
-          // in the path.
-          // file = file.getCanonicalFile();
-          java.io.File f = new java.io.File(file.getPath());
-          java.io.File absolute = null == f ? null : f.getAbsoluteFile();
-          if ( null != absolute ) {
-            // Of course, IDEA's notion of a URI requires "://" after the protocol separator
-            // (as opposed to Java's ":").  So we can't just use the Java URI.
-            VirtualFileManager vfm = VirtualFileManager.getInstance();
-            String canonicalUri = absolute.toURI().toString();
-            String ideaUri = vfm.constructUrl(absolute.toURI().getScheme(), absolute.getPath());
-            file = VirtualFileManager.getInstance().findFileByUrl(ideaUri);
-          }
+        if (null != file) {
+          file = HaxeFileUtil.getCanonicalFile(file);
         }
 
         mSourcePosition =

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
@@ -518,6 +518,7 @@ public class HaxelibClasspathUtils {
         }
         VirtualFile dirName = vfmInstance.findFileByUrl(dirUrl);
         if (null != dirName && dirName.isDirectory()) {
+          // XXX: This is wrong if filePath is already an absolute file name.
           found = dirName.findFileByRelativePath(filePath);
           if (null != found) {
             return false;  // Stop the search.
@@ -565,11 +566,11 @@ public class HaxelibClasspathUtils {
         }
         VirtualFile dirName = vfmInstance.findFileByUrl(dirUrl);
         if (null != dirName && dirName.isDirectory()) {
-          String dirPath = dirName.getCanonicalPath();
+          String dirPath = dirName.getPath();
           for (VirtualFile f : files) {
             if (f.exists()) {
               // We have a complete path, compare the leading paths.
-              String filePath = f.getCanonicalPath();
+              String filePath = f.getPath();
               if (filePath.startsWith(dirPath)) {
                 found = f;
               }

--- a/src/common/com/intellij/plugins/haxe/util/HaxeFileUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeFileUtil.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Eric Bishton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.openapi.vfs.VirtualFileManager;
+
+import java.io.IOException;
+
+/**
+ * Created by ebishton on 8/10/17.
+ */
+public class HaxeFileUtil {
+
+  private HaxeFileUtil() {}
+
+  /**
+   * Get the canonical name of a file, even when the directories are symlinks.
+   *
+   * @param file
+   * @return
+   */
+  public static VirtualFile getCanonicalFile(VirtualFile file) {
+    try {
+      java.io.File f = new java.io.File(file.getPath());
+      java.io.File absolute = null == f ? null : f.getCanonicalFile();
+      if (null != absolute) {
+        // Of course, IDEA's notion of a URI requires "://" after the protocol separator
+        // (as opposed to Java's ":").  So we can't just use the Java URI.
+        VirtualFileManager vfm = VirtualFileManager.getInstance();
+        String canonicalUri = absolute.toURI().toString();
+        String ideaUri = vfm.constructUrl(absolute.toURI().getScheme(), absolute.getPath());
+        return VirtualFileManager.getInstance().findFileByUrl(ideaUri);
+      }
+    } catch(IOException e) {
+      ; // Swallow
+    }
+    return null;
+  }
+
+}


### PR DESCRIPTION
Hardens debugger code that locates original source files and opens source buffers when they (or intermediate directories) have been symlinked.