### PR TITLE
Fix an IllegalArgumentException running the ProjectUpdater...

### DIFF
--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
@@ -231,7 +231,12 @@ public class HaxelibProjectUpdater {
 
     toAdd = new HaxeLibraryList(module);
     toRemove = new HaxeLibraryList(module);
-    syncLibraryLists(ModuleRootManager.getInstance(module).getSdk(),
+    Sdk moduleSdk = ModuleRootManager.getInstance(module).getSdk();
+    if (null == moduleSdk) {
+      LOG.debug("No SDK for module " + module.getName() + ".  Not syncing haxelibs.");
+      return; // Nothing to do if there is no SDK.
+    }
+    syncLibraryLists(moduleSdk,
                      HaxelibUtil.getModuleLibraries(module),
                      externalLibs,
         /*modifies*/ toAdd,


### PR DESCRIPTION
when a module doesn't have an SDK set up properly.