### PR TITLE
Use non-Haxe-logo icons for completion items that are not provided by…

### DIFF
--- a/src/common/com/intellij/plugins/haxe/HaxeComponentType.java
+++ b/src/common/com/intellij/plugins/haxe/HaxeComponentType.java
@@ -34,15 +34,27 @@ public enum HaxeComponentType {
     public Icon getIcon() {
       return icons.HaxeIcons.C_Haxe;
     }
+    @Override
+    public Icon getCompletionIcon() {
+      return AllIcons.Nodes.Class;
+    }
   }, ENUM(1) {
     @Override
     public Icon getIcon() {
       return icons.HaxeIcons.E_Haxe;
     }
+    @Override
+    public Icon getCompletionIcon() {
+      return AllIcons.Nodes.Enum;
+    }
   }, INTERFACE(2) {
     @Override
     public Icon getIcon() {
       return icons.HaxeIcons.I_Haxe;
+    }
+    @Override
+    public Icon getCompletionIcon() {
+      return AllIcons.Nodes.Interface;
     }
   }, FUNCTION(3) {
     @Override
@@ -92,6 +104,10 @@ public enum HaxeComponentType {
   }
 
   public abstract Icon getIcon();
+
+  public Icon getCompletionIcon() {
+    return getIcon();
+  }
 
   public static boolean isVariable(@Nullable HaxeComponentType type) {
     return type == VARIABLE || type == PARAMETER || type == FIELD;

--- a/src/common/com/intellij/plugins/haxe/ide/completion/HaxeClassNameCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/completion/HaxeClassNameCompletionContributor.java
@@ -187,7 +187,7 @@ public class HaxeClassNameCompletionContributor extends CompletionContributor {
         String name = pair.getFirst();
         final String qName = HaxeResolveUtil.joinQName(info.getValue(), name);
         myResultSet.addElement(LookupElementBuilder.create(qName, name)
-                                 .withIcon(info.getIcon())
+                                 .withIcon(info.getCompletionIcon())
                                  .withTailText(" " + info.getValue(), true)
                                  .withInsertHandler(myInsertHandler));
       }

--- a/src/common/com/intellij/plugins/haxe/ide/index/HaxeClassInfo.java
+++ b/src/common/com/intellij/plugins/haxe/ide/index/HaxeClassInfo.java
@@ -50,6 +50,11 @@ public class HaxeClassInfo {
     return type == null ? null : type.getIcon();
   }
 
+  @Nullable
+  public Icon getCompletionIcon() {
+    return type == null ? null : type.getCompletionIcon();
+  }
+
   private int getTypeKey() {
     return type != null ? type.getKey() : -1;
   }


### PR DESCRIPTION
… the compiler.  (Fixes #764.)