### PR TITLE
Haxe Sdk setup validator

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -80,6 +80,10 @@
       <p>This jar is compatible with @plugin.compatibility.description@</p>
       <p>It was built using IDEA build @idea.sdk.version@</p>
       <p/>
+      <p>Unreleased changes</p>
+      <ul>
+        <li>Add Haxe Sdk setup validation</li>
+      </ul>
       <p>1.0.0 (HaxeFoundation release)</p>
       <ul>
         <li>Add $trace to the list of built-ins to recognize.</li>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -788,6 +788,7 @@
     <moduleConfigurationEditorProvider
         implementation="com.intellij.plugins.haxe.ide.projectStructure.HaxeModuleConfigurationEditorProvider"/>
     <projectStructureDetector implementation="com.intellij.plugins.haxe.ide.projectStructure.detection.HaxeProjectStructureDetector"/>
+    <projectSdkSetupValidator id="haxeSdk" implementation="com.intellij.plugins.haxe.codeInsight.daemon.HaxeProjectSdkSetupValidator"/>
 
     <library.type implementation="com.intellij.plugins.haxe.ide.library.HaxeLibraryType"/>
 

--- a/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -152,6 +152,7 @@ haxe.lookup.alias=alias for {0}
 hxml.language.id = HXML
 hxml.file.type.name = HXML
 hxml.file.type.description = Haxe Build Files
+sdk.roots.misconfigured=Haxe SDK roots misconfigured. That may lead to unexpected behavior during types resolving!
 
 # HAXE tests
 

--- a/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -152,7 +152,8 @@ haxe.lookup.alias=alias for {0}
 hxml.language.id = HXML
 hxml.file.type.name = HXML
 hxml.file.type.description = Haxe Build Files
-sdk.roots.misconfigured=Haxe SDK roots misconfigured. That may lead to unexpected behavior during types resolving!
+sdk.roots.multiple=Haxe SDK has multiple roots. This may lead to unexpected behavior.
+sdk.roots.no.valid.root=Haxe SDK has no valid root. Set up or change SDK.
 
 # HAXE tests
 

--- a/src/common/com/intellij/plugins/haxe/codeInsight/daemon/HaxeProjectSdkSetupValidator.java
+++ b/src/common/com/intellij/plugins/haxe/codeInsight/daemon/HaxeProjectSdkSetupValidator.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018-2018 Ilya Malanin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.codeInsight.daemon;
+
+import com.intellij.codeInsight.daemon.impl.JavaProjectSdkSetupValidator;
+import com.intellij.openapi.application.WriteAction;
+import com.intellij.openapi.module.Module;
+import com.intellij.openapi.module.ModuleUtilCore;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectBundle;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.SdkModificator;
+import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.openapi.roots.ModuleRootModificationUtil;
+import com.intellij.openapi.roots.OrderRootType;
+import com.intellij.openapi.roots.ui.configuration.ProjectSettingsService;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.plugins.haxe.HaxeBundle;
+import com.intellij.plugins.haxe.HaxeLanguage;
+import com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
+import one.util.streamex.StreamEx;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.intellij.plugins.haxe.codeInsight.daemon.SdkValidationResult.*;
+import static com.intellij.plugins.haxe.model.HaxeProjectModel.STD_TYPES_HX;
+
+public class HaxeProjectSdkSetupValidator extends JavaProjectSdkSetupValidator {
+
+  @Override
+  public boolean isApplicableFor(@NotNull Project project, @NotNull VirtualFile file) {
+    final PsiFile psiFile = PsiManager.getInstance(project).findFile(file);
+    return psiFile != null && psiFile.getLanguage().isKindOf(HaxeLanguage.INSTANCE);
+  }
+
+  @Nullable
+  @Override
+  public String getErrorMessage(@NotNull Project project, @NotNull VirtualFile file) {
+    SdkValidationResult result = validateSdk(project, file);
+    if (result != null) {
+      switch (result) {
+        case MODULE_SDK_NOT_DEFINED:
+          return ProjectBundle.message("module.sdk.not.defined");
+        case PROJECT_SDK_NOT_DEFINED:
+          return ProjectBundle.message("project.sdk.not.defined");
+        case MULTIPLE_OR_EMPTY_SDK_ROOTS:
+          return HaxeBundle.message("sdk.roots.misconfigured");
+      }
+    }
+
+    return null;
+  }
+
+  private SdkValidationResult validateSdk(Project project, VirtualFile file) {
+    final Module module = ModuleUtilCore.findModuleForFile(file, project);
+    if (module != null && !module.isDisposed()) {
+      final Sdk sdk = ModuleRootManager.getInstance(module).getSdk();
+      if (sdk == null) {
+        if (ModuleRootManager.getInstance(module).isSdkInherited()) {
+          return PROJECT_SDK_NOT_DEFINED;
+        } else {
+          return MODULE_SDK_NOT_DEFINED;
+        }
+      } else {
+        return validateSdkRoots(sdk);
+      }
+    }
+    return null;
+  }
+
+  private SdkValidationResult validateSdkRoots(Sdk sdk) {
+    List<VirtualFile> roots = StreamEx.of(sdk.getRootProvider().getFiles(OrderRootType.CLASSES))
+      .append(sdk.getRootProvider().getFiles(OrderRootType.SOURCES))
+      .distinct()
+      .collect(Collectors.toList());
+
+    if (hasNoValidRoots(roots)) {
+      return NO_VALID_SDK_ROOTS_FOUND;
+    }
+    if (hasMultipleOrEmptyRoots(roots)) {
+      return MULTIPLE_OR_EMPTY_SDK_ROOTS;
+    }
+
+    return null;
+  }
+
+  private boolean hasNoValidRoots(List<VirtualFile> roots) {
+    return roots.stream().noneMatch(root -> root.findChild(STD_TYPES_HX) != null);
+  }
+
+  private boolean hasMultipleOrEmptyRoots(List<VirtualFile> roots) {
+    return roots.size() != 1;
+  }
+
+  @Override
+  public void doFix(@NotNull Project project, @NotNull VirtualFile file) {
+    SdkValidationResult result = validateSdk(project, file);
+    if (result == null) {
+      return;
+    }
+
+    switch (result) {
+      case PROJECT_SDK_NOT_DEFINED:
+      case MODULE_SDK_NOT_DEFINED:
+      case NO_VALID_SDK_ROOTS_FOUND:
+        super.doFix(project, file);
+      case MULTIPLE_OR_EMPTY_SDK_ROOTS:
+        pruneExcessiveRoots(project, file);
+        break;
+    }
+    super.doFix(project, file);
+  }
+
+  private void pruneExcessiveRoots(Project project, VirtualFile file) {
+    final Module module = ModuleUtilCore.findModuleForFile(file, project);
+    if (module != null && !module.isDisposed()) {
+      final Sdk sdk = ModuleRootManager.getInstance(module).getSdk();
+      if (sdk != null) {
+        final SdkModificator modificator = sdk.getSdkModificator();
+        //modificator.
+        //  stdRoot = StreamEx.of(modificator.getRoots(OrderRootType.CLASSES))
+        //  .append(modificator.getRoots(OrderRootType.SOURCES))
+        //  .append(stdRoot)
+        //  .distinct()
+        //  .filter(root -> root.findChild(STD_TYPES_HX) != null)
+        //  .findFirst()
+        //  .orElse(null);
+        //
+        //if (stdRoot != null) {
+        //  modificator.removeAllRoots();
+        //  modificator.addRoot(stdRoot, OrderRootType.CLASSES);
+        //  modificator.addRoot(stdRoot, OrderRootType.SOURCES);
+        //}
+      }
+    }
+  }
+}
+
+enum SdkValidationResult {
+  PROJECT_SDK_NOT_DEFINED,
+  MODULE_SDK_NOT_DEFINED,
+  MULTIPLE_OR_EMPTY_SDK_ROOTS,
+  NO_VALID_SDK_ROOTS_FOUND
+}

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
@@ -35,6 +35,7 @@ import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.Processor;
 import org.apache.log4j.Level;
+import org.fest.util.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -169,7 +170,7 @@ public class HaxelibUtil {
       }
       return installedHaxelibs;
     }
-    return Collections.EMPTY_LIST;
+    return Lists.emptyList();
   }
 
 

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
@@ -35,7 +35,6 @@ import com.intellij.psi.xml.XmlFile;
 import com.intellij.psi.xml.XmlTag;
 import com.intellij.util.Processor;
 import org.apache.log4j.Level;
-import org.fest.util.Lists;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -170,7 +169,7 @@ public class HaxelibUtil {
       }
       return installedHaxelibs;
     }
-    return Lists.emptyList();
+    return Collections.emptyList();
   }
 
 

--- a/src/common/com/intellij/plugins/haxe/model/HaxeProjectModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeProjectModel.java
@@ -29,9 +29,9 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-public class HaxeProjectModel {
-  public static final String STD_TYPES_HX = "StdTypes.hx";
+import static com.intellij.plugins.haxe.model.HaxeStdTypesFileModel.STD_TYPES_HX;
 
+public class HaxeProjectModel {
   private final Project project;
   private final HaxePackageModel stdPackage;
   private final HaxeSourceRootModel sdkRoot;

--- a/src/common/com/intellij/plugins/haxe/model/HaxeProjectModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeProjectModel.java
@@ -30,6 +30,8 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class HaxeProjectModel {
+  public static final String STD_TYPES_HX = "StdTypes.hx";
+
   private final Project project;
   private final HaxePackageModel stdPackage;
   private final HaxeSourceRootModel sdkRoot;
@@ -41,9 +43,9 @@ public class HaxeProjectModel {
   }
 
   private HaxeSourceRootModel resolveSdkRoot() {
-    final VirtualFile[] roots;
-
     if (ApplicationManager.getApplication().isUnitTestMode()) {
+      final VirtualFile[] roots;
+
       roots = OrderEnumerator.orderEntries(project).getAllSourceRoots();
       if (roots.length > 0) {
         VirtualFile stdRootForTests = roots[0].findChild("std");
@@ -52,13 +54,23 @@ public class HaxeProjectModel {
         }
       }
     } else {
-      roots = OrderEnumerator.orderEntries(project).sdkOnly().getAllSourceRoots();
-      if (roots.length > 0) {
-        return new HaxeSourceRootModel(this, roots[0]);
+      VirtualFile root = detectProperSDKSourceRoot(OrderEnumerator.orderEntries(project).sdkOnly().getAllSourceRoots());
+
+      if (root != null) {
+        return new HaxeSourceRootModel(this, root);
       }
     }
     return HaxeSourceRootModel.DUMMY;
   }
+
+  private VirtualFile detectProperSDKSourceRoot(VirtualFile[] roots) {
+    for (VirtualFile root : roots) {
+      if (root.findChild(STD_TYPES_HX) != null) return root;
+    }
+
+    return null;
+  }
+
 
   public static HaxeProjectModel fromElement(PsiElement element) {
     return fromProject(element.getProject());

--- a/src/common/com/intellij/plugins/haxe/model/HaxeStdTypesFileModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeStdTypesFileModel.java
@@ -19,6 +19,7 @@ import com.intellij.plugins.haxe.lang.psi.HaxeFile;
 import org.jetbrains.annotations.NotNull;
 
 public class HaxeStdTypesFileModel extends HaxeFileModel {
+  public static final String STD_TYPES_HX = "StdTypes.hx";
 
   public HaxeStdTypesFileModel(@NotNull HaxeFile file) {
     super(file);


### PR DESCRIPTION
- Add detection of missing sdk
- Add detection of multiple and wrong roots for Sdk
- Add "Setup fix" in two ways: 
  - Define module (or project and module) Sdk in case if it's missing or don't have a valid root
  - Pruning of excessive roots for defined Sdk

Closes #770 