### PR TITLE
Build compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ before_script:
 script: make ANT_TARGET=$ANT_TARGET test
 env:
     - IDEA_VERSION=2016.3.7 ANT_TARGET=test
-    - IDEA_VERSION=2017.1.5 ANT_TARGET=test
     - IDEA_VERSION=2017.2.6 ANT_TARGET=test
+    - IDEA_VERSION=2017.3.6 ANT_TARGET=test
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_script:
 - mkdir report
 script: make ANT_TARGET=$ANT_TARGET test
 env:
-    - IDEA_VERSION=2016.3.7 ANT_TARGET=test
-    - IDEA_VERSION=2017.2.6 ANT_TARGET=test
-    - IDEA_VERSION=2017.3.6 ANT_TARGET=test
+    - IDEA_VERSION=2016.3.8 ANT_TARGET=test
+    - IDEA_VERSION=2017.2.7 ANT_TARGET=test
+    - IDEA_VERSION=2017.3.5 ANT_TARGET=test
     - IDEA_VERSION=2018.1 ANT_TARGET=test
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - IDEA_VERSION=2016.3.7 ANT_TARGET=test
     - IDEA_VERSION=2017.2.6 ANT_TARGET=test
     - IDEA_VERSION=2017.3.6 ANT_TARGET=test
+    - IDEA_VERSION=2018.1 ANT_TARGET=test
 
 notifications:
   email: false

--- a/common.xml
+++ b/common.xml
@@ -125,7 +125,7 @@
         case 183:   propertiesFile = "idea_v18.properties";   break;
         case 182:   propertiesFile = "idea_v18.properties";   break;
         case 181:   propertiesFile = "idea_v18.properties";   break;
-        case 173:   propertiesFile = "idea_v17.properties";   break;
+        case 173:   propertiesFile = "idea_v17.3.properties"; break;
         case 172:   propertiesFile = "idea_v17.properties";   break;
         case 171:   propertiesFile = "idea_v17.properties";   break;
         case 163:   propertiesFile = "idea_v16.properties";   break;

--- a/idea_v17.3.properties
+++ b/idea_v17.3.properties
@@ -1,13 +1,27 @@
 #
-# Properties for building against IDEA version 17.
+# Properties for building against IDEA version 2017.3.
 #
+
+
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#
+#  N o t e :
+#
+#    It is not strictly necessary to have a 2017.3 version
+#    of this plugin, because plugins built with IDEA
+#    2017.1 or .2 will work in 2017.3.  However, versions
+#    built with 2017.3 will NOT work with earlier versions
+#    of IDEA because of changes in the class loaders.
+#
+# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
 
 # Target version of IDEA that we typically build for.
 # This is appended to the name of the intellij-haxe-XXX jar file.
-idea.version=2017.1-2
+idea.version=2017.3
 
 # Human-readable versions of IDEA that this build is compatible with.
-plugin.compatibility.description=IDEA 2017.1 through 2017.2
+plugin.compatibility.description=IDEA 2017.3.x
 
 # ###################################################
 # IDEA build IDs that are compatible with this plugin.
@@ -15,11 +29,11 @@ plugin.compatibility.description=IDEA 2017.1 through 2017.2
 #
 # IDEA builds prior to this one will not install this plugin.
 #
-plugin.installable.since=171.1
+plugin.installable.since=173.1
 #
 # IDEA builds after this one will not install this plugin.
 #
-plugin.installable.until=172.*
+plugin.installable.until=173.*
 
 # ###################################################
 # Where to find Idea17-specific code.

--- a/testSrc/com/intellij/plugins/haxe/HaxeCodeInsightFixtureTestCase.java
+++ b/testSrc/com/intellij/plugins/haxe/HaxeCodeInsightFixtureTestCase.java
@@ -20,6 +20,7 @@ package com.intellij.plugins.haxe;
 import com.intellij.codeInspection.InspectionProfileEntry;
 import com.intellij.plugins.haxe.build.ClassWrapper;
 import com.intellij.plugins.haxe.build.IdeaTarget;
+import com.intellij.plugins.haxe.build.MethodWrapper;
 import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeTestUtils;
 import com.intellij.testFramework.PlatformTestCase;
@@ -33,7 +34,10 @@ abstract public class HaxeCodeInsightFixtureTestCase extends JavaCodeInsightFixt
   protected HaxeCodeInsightFixtureTestCase() {
     super();
     HaxeDebugLogger.configurePrimaryLoggerToSwallowLogs();
-    PlatformTestCase.initPlatformLangPrefix();
+    if (!IdeaTarget.IS_VERSION_18_COMPATIBLE) {
+      MethodWrapper<Void> init = new MethodWrapper<>(PlatformTestCase.class, "initPlatformLangPrefix", null);
+      init.invoke(null,null);
+    }
   }
 
   @Override

--- a/testSrc/com/intellij/plugins/haxe/actions/HaxeGenerateActionTest.java
+++ b/testSrc/com/intellij/plugins/haxe/actions/HaxeGenerateActionTest.java
@@ -18,6 +18,8 @@
 package com.intellij.plugins.haxe.actions;
 
 import com.intellij.openapi.util.io.FileUtil;
+import com.intellij.plugins.haxe.build.IdeaTarget;
+import com.intellij.plugins.haxe.build.MethodWrapper;
 import com.intellij.plugins.haxe.ide.generation.*;
 import com.intellij.plugins.haxe.util.HaxeTestUtils;
 import com.intellij.testFramework.LightPlatformCodeInsightTestCase;
@@ -30,7 +32,10 @@ import org.jetbrains.annotations.NotNull;
 public class HaxeGenerateActionTest extends LightPlatformCodeInsightTestCase {
   @SuppressWarnings("JUnitTestCaseWithNonTrivialConstructors")
   public HaxeGenerateActionTest() {
-    PlatformTestCase.initPlatformLangPrefix();
+    if (!IdeaTarget.IS_VERSION_18_COMPATIBLE) {
+      MethodWrapper<Void> init = new MethodWrapper<>(PlatformTestCase.class, "initPlatformLangPrefix", null);
+      init.invoke(null,null);
+    }
   }
 
   @NotNull


### PR DESCRIPTION
2017.3 build gets its own jar to avoid run-time issues when running a 2017.3 built jar in earlier releases.
2018.1 gets its own jar, too.  Now builds and runs all tests.