### PR TITLE
Correcting case for case sensitive haxelib attribute

### DIFF
--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibMetadata.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibMetadata.java
@@ -81,7 +81,7 @@ public class HaxelibMetadata {
   public static String TAGS = "tags";
   public static String DESCRIPTION = "description";
   public static String VERSION = "version";
-  public static String CLASSPATH = "classpath";
+  public static String CLASSPATH = "classPath";
   public static String RELEASENOTE = "releasenote";
   public static String CONTRIBUTORS = "contributors";
   public static String DEPENDENCIES = "dependencies";


### PR DESCRIPTION
Correcting CLASSPATH attribute value to match haxelibs casing 
(ref: https://lib.haxe.org/documentation/creating-a-haxelib-package/)

This should fix the problem where the plugin does not detect the source directory properly.
