### PR TITLE
#792 Fix for debugger crash

### DIFF
--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
@@ -273,7 +273,7 @@ public class HaxelibClasspathUtils {
    */
   @NotNull
   public static HaxeClasspath getFullClasspath(@NotNull Module module) {
-    HaxeClasspath classpath = getImplicitClassPath(module);
+    HaxeClasspath classpath = new HaxeClasspath(getImplicitClassPath(module));
     classpath.addAll(getModuleClasspath(module));
     classpath.addAll(getProjectLibraryClasspath(module.getProject()));
     // This grabs either the module's SDK, or the inherited one, if any.


### PR DESCRIPTION
Fix hxcpp debugger crash (getFullClasspath tried to add to immutable set returned by getImplicitClassPath) simplest solution without any big or drastic changes to the code.