### PR TITLE
Fixed capturing of PsiElement in HaxeFileModel and HaxeStdTypesFileModel

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -84,6 +84,7 @@
       <ul>
         <li>Add support of <a href="https://github.com/HaxeFoundation/haxe-evolution/blob/master/proposals/0003-new-function-type.md">new function types syntax</a> introduced in Haxe 4</li>
         <li>Fix of support of explicit abstract forwards. Now fields and methods that has not been forwarded will not be resolved as valid.</li>
+        <li>Fixed recognition of standard types</li>
       </ul>
       <p>1.0.2 (HaxeFoundation release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/model/HaxeFileModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeFileModel.java
@@ -15,6 +15,7 @@
  */
 package com.intellij.plugins.haxe.model;
 
+import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.util.HaxeAddImportHelper;
@@ -33,9 +34,10 @@ import java.util.stream.Stream;
 
 public class HaxeFileModel implements HaxeExposableModel {
 
+  protected static final Key<HaxeFileModel> HAXE_FILE_MODEL_KEY = new Key<>("HAXE_FILE_MODEL");
   private final HaxeFile file;
 
-  public HaxeFileModel(@NotNull HaxeFile file) {
+  protected HaxeFileModel(@NotNull HaxeFile file) {
     this.file = file;
   }
 
@@ -44,8 +46,13 @@ public class HaxeFileModel implements HaxeExposableModel {
     if (element == null) return null;
 
     final PsiFile file = element instanceof PsiFile ? (PsiFile)element : element.getContainingFile();
-    if (file != null) {
-      return new HaxeFileModel((HaxeFile)file);
+    if (file instanceof HaxeFile) {
+      HaxeFileModel model = file.getUserData(HAXE_FILE_MODEL_KEY);
+      if (model == null) {
+        model = new HaxeFileModel((HaxeFile)file);
+        file.putUserData(HAXE_FILE_MODEL_KEY, model);
+      }
+      return model;
     }
     return null;
   }

--- a/src/common/com/intellij/plugins/haxe/model/HaxePackageModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxePackageModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2017 Ilya Malanin
+ * Copyright 2017-2018 Ilya Malanin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,7 +122,7 @@ public class HaxePackageModel implements HaxeExposableModel {
   @Nullable
   public HaxeFileModel getFileModel(String fileName) {
     final HaxeFile file = getFile(fileName);
-    return file != null ? new HaxeFileModel(file) : null;
+    return file != null ? HaxeFileModel.fromElement(file) : null;
   }
 
   protected HaxeFile getFile(String fileName) {

--- a/src/common/com/intellij/plugins/haxe/model/HaxeStdPackageModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeStdPackageModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2017 Ilya Malanin
+ * Copyright 2017-2018 Ilya Malanin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,17 +21,15 @@ import org.jetbrains.annotations.Nullable;
 
 public class HaxeStdPackageModel extends HaxePackageModel {
   private static final String STD_TYPES = "StdTypes";
-  private final HaxeFileModel stdTypesModel;
 
   HaxeStdPackageModel(@NotNull HaxeSourceRootModel root) {
     super(root, "", null);
-    this.stdTypesModel = this.getStdFileModel();
   }
 
   private HaxeFileModel getStdFileModel() {
     final HaxeFile file = getFile(STD_TYPES);
     if (file != null) {
-      return new HaxeStdTypesFileModel(file);
+      return HaxeStdTypesFileModel.fromFile(file);
     }
     return null;
   }
@@ -41,6 +39,7 @@ public class HaxeStdPackageModel extends HaxePackageModel {
   public HaxeClassModel getClassModel(@NotNull String className) {
     HaxeClassModel result = super.getClassModel(className);
 
+    HaxeFileModel stdTypesModel = getStdFileModel();
     if (result == null && stdTypesModel != null) {
       result = stdTypesModel.getClassModel(className);
     }
@@ -52,6 +51,7 @@ public class HaxeStdPackageModel extends HaxePackageModel {
   public HaxeModel resolve(FullyQualifiedInfo info) {
     HaxeModel result = super.resolve(info);
 
+    HaxeFileModel stdTypesModel = getStdFileModel();
     if (result == null && stdTypesModel != null && info.packagePath.isEmpty() && this.path.isEmpty()) {
       result = stdTypesModel.resolve(new FullyQualifiedInfo("", null, info.fileName, info.memberName));
     }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeStdTypesFileModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeStdTypesFileModel.java
@@ -15,18 +15,29 @@
  */
 package com.intellij.plugins.haxe.model;
 
+import com.intellij.openapi.util.Key;
 import com.intellij.plugins.haxe.lang.psi.HaxeFile;
 import org.jetbrains.annotations.NotNull;
 
 public class HaxeStdTypesFileModel extends HaxeFileModel {
   public static final String STD_TYPES_HX = "StdTypes.hx";
+  private static final Key<HaxeStdTypesFileModel> HAXE_STD_FILE_MODEL_KEY = new Key<>("HAXE_STD_FILE_MODEL");
 
-  public HaxeStdTypesFileModel(@NotNull HaxeFile file) {
+  private HaxeStdTypesFileModel(@NotNull HaxeFile file) {
     super(file);
   }
 
   @Override
   protected boolean isReferencingCurrentFile(FullyQualifiedInfo info) {
     return (info.packagePath == null || info.packagePath.isEmpty()) && (info.fileName == null || info.fileName.isEmpty());
+  }
+
+  public static HaxeStdTypesFileModel fromFile(@NotNull HaxeFile file) {
+    HaxeStdTypesFileModel model = file.getUserData(HAXE_STD_FILE_MODEL_KEY);
+    if (model == null) {
+      model = new HaxeStdTypesFileModel(file);
+      file.putUserData(HAXE_STD_FILE_MODEL_KEY, model);
+    }
+    return model;
   }
 }


### PR DESCRIPTION
Right now file models are capturing PsiElements forever, and after reparsing of PsiElements there is no new models are creating, this leads to behavior when models are trying to access invalid PsiElements.

This PR closes that problem, as it was done previously for other models.