### PR TITLE
Add type dropdown for type when ':' is pressed and a type is expected.

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -82,6 +82,7 @@
       <p/>
       <p>Unreleased changes</p>
       <ul>
+        <li>Add completion dropdown when ':' is typed and a type is expected.</li>
         <li>Add support of <a href="https://github.com/HaxeFoundation/haxe/pull/6596">final syntax</a> introduced in Haxe 4</li>
         <li>Add support of <a href="https://github.com/HaxeFoundation/haxe-evolution/blob/master/proposals/0003-new-function-type.md">new function types syntax</a> introduced in Haxe 4</li>
         <li>Fix of support of explicit abstract forwards. Now fields and methods that has not been forwarded will not be resolved as valid.</li>

--- a/src/common/com/intellij/plugins/haxe/ide/completion/HaxeClassNameCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/completion/HaxeClassNameCompletionContributor.java
@@ -3,6 +3,7 @@
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2018 Ilya Malanin
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +70,20 @@ public class HaxeClassNameCompletionContributor extends CompletionContributor {
 
     extend(CompletionType.BASIC,
            isSimpleIdentifier.andNot(inImportOrUsing),
+           new CompletionProvider<CompletionParameters>() {
+             @Override
+             protected void addCompletions(@NotNull CompletionParameters parameters,
+                                           ProcessingContext context,
+                                           @NotNull CompletionResultSet result) {
+               final PsiFile file = parameters.getOriginalFile();
+
+               addVariantsFromIndex(result, file, null, CLASS_INSERT_HANDLER);
+               addVariantsFromImports(result, file);
+             }
+           });
+
+    extend(CompletionType.SMART,
+           inFunctionTypeTag,
            new CompletionProvider<CompletionParameters>() {
              @Override
              protected void addCompletions(@NotNull CompletionParameters parameters,

--- a/src/common/com/intellij/plugins/haxe/ide/completion/HaxeCommonCompletionPattern.java
+++ b/src/common/com/intellij/plugins/haxe/ide/completion/HaxeCommonCompletionPattern.java
@@ -1,8 +1,6 @@
 /*
- * Copyright 2000-2013 JetBrains s.r.o.
- * Copyright 2014-2014 AS3Boyan
- * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2018 Ilya Malanin
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,24 +16,128 @@
  */
 package com.intellij.plugins.haxe.ide.completion;
 
-import com.intellij.patterns.PsiElementPattern;
-import com.intellij.patterns.StandardPatterns;
+import com.intellij.patterns.*;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
+import com.intellij.plugins.haxe.util.HaxeDebugPsiUtil;
 import com.intellij.psi.PsiElement;
+import com.intellij.util.ProcessingContext;
+import org.apache.log4j.Level;
+import org.jetbrains.annotations.Nullable;
 
 import static com.intellij.patterns.PlatformPatterns.psiElement;
 
 public class HaxeCommonCompletionPattern {
   public static final PsiElementPattern.Capture<PsiElement> idInExpression =
-    psiElement().withSuperParent(1, HaxeIdentifier.class).withSuperParent(2, HaxeReference.class);
+    elementPattern("idInExpression")
+      .withSuperParent(1, HaxeIdentifier.class)
+      .withSuperParent(2, HaxeReference.class);
   public static final PsiElementPattern.Capture<PsiElement> inComplexExpression =
-    psiElement().withSuperParent(2, psiElement().withFirstChild(StandardPatterns.instanceOf(HaxeReference.class)));
+    elementPattern("inComplexExpression")
+      .withSuperParent(2,
+         psiElement()
+           .withFirstChild(StandardPatterns.instanceOf(HaxeReference.class)));
   public static final PsiElementPattern.Capture<PsiElement> isSimpleIdentifier =
-    psiElement().andOr(StandardPatterns.instanceOf(HaxeType.class), idInExpression.andNot(inComplexExpression));
+    elementPattern("isSimpleIdentifier")
+      .andOr(StandardPatterns.instanceOf(HaxeType.class),
+             idInExpression.andNot(inComplexExpression));
 
-  public static final PsiElementPattern.Capture<PsiElement> matchUsingAndImport = psiElement().andOr(
-    StandardPatterns.instanceOf(HaxeUsingStatement.class),
-    StandardPatterns.instanceOf(HaxeImportStatement.class));
+  public static final PsiElementPattern.Capture<PsiElement> matchUsingAndImport =
+    elementPattern("matchUsingAndImport")
+      .andOr(StandardPatterns.instanceOf(HaxeUsingStatement.class),
+             StandardPatterns.instanceOf(HaxeImportStatement.class));
 
-  public static final PsiElementPattern.Capture<PsiElement> inImportOrUsing = psiElement().withSuperParent(3, matchUsingAndImport);
+  public static final PsiElementPattern.Capture<PsiElement> inImportOrUsing =
+    elementPattern("inImportOrUsing")
+      .withSuperParent(3, matchUsingAndImport);
+
+  public static final PsiElementPattern.Capture<PsiElement> skippableWhitespace =
+    elementPattern("skippableWhitespace")
+      .andOr(psiElement().withText(" "),
+             psiElement().withText("\t"));
+  public static final PsiElementPattern.Capture<PsiElement> inSwitchStatement =
+    elementPattern("inSwitchStatement")
+      .andOr(
+        psiElement().withSuperParent(3,HaxeSwitchBlock.class),
+        psiElement().withSuperParent(3,HaxeSwitchCase.class),
+        psiElement().withSuperParent(3,HaxeDefaultCase.class),
+        psiElement().withSuperParent(3,HaxeSwitchCaseBlock.class),
+        psiElement().afterSiblingSkipping(skippableWhitespace,psiElement(HaxeSwitchStatement.class)) // Syntax error in stmt.
+      );
+  public static final PsiElementPattern.Capture<PsiElement> inFunctionTypeTag =
+    elementPattern("inFunctionTypeTag")
+      .afterLeafSkipping(skippableWhitespace, psiElement().withText(":"))
+      .andNot(inSwitchStatement)
+      ;
+
+  /**
+   * Create a new capture rule that requires the matched token to be a
+   * PsiElement.
+   *
+   * Use this as the root capture rule instead of psiElement() when creating
+   * rules that may need debugging.
+   *
+   * Note that you may have to cast the result of a chained rule to a
+   * HaxeCapturePattern.
+   *
+   * @return a pattern that ensures the token is a PsiElement.
+   */
+  private static HaxeElementPattern<PsiElement> elementPattern(String name) {
+    return pattern(name, new InitialPatternCondition<PsiElement>(PsiElement.class){
+      @Override
+      public boolean accepts(@Nullable Object o, ProcessingContext context) {
+        return o instanceof PsiElement;
+      }
+    });
+  }
+
+  private static <T extends PsiElement> HaxeElementPattern<T> pattern(
+    String name,
+    InitialPatternCondition<T> capture) {
+    return new HaxeElementPattern<>(name, capture);
+  }
+
+  /**
+   * A wrapper around PsiElementPattern.Capture<> that can print the actual element,
+   * context, and match pattern to which it applies.
+   * @param <T>
+   */
+  private static class HaxeElementPattern<T extends PsiElement> extends PsiElementPattern.Capture<T> {
+
+    static final HaxeDebugLogger LOG = HaxeDebugLogger.getLogger();
+    static {
+      // Use when you want to see the match pattern and parents.
+      // LOG.setLevel(Level.DEBUG);
+
+      // Use when you want the full local PSI tree (two parents up)
+      // LOG.setLevel(Level.TRACE);
+    }
+
+    String myName;
+
+    public HaxeElementPattern(String name, final InitialPatternCondition<T> pattern) {
+      super(pattern);
+      myName = name;
+    }
+
+    @Override
+    public boolean accepts(@Nullable Object o, ProcessingContext context) {
+      boolean matches = super.accepts(o, context);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Pattern " + myName + " " + (matches ? "matched" : "failed")
+                  + ": " + toString());
+        LOG.debug("For " + o.getClass() + "\n" +
+                  (o instanceof PsiElement
+                   ? "with path\n" + HaxeDebugPsiUtil.formatElementPath((PsiElement)o, false)
+                   : ""));
+        if (o instanceof PsiElement && LOG.isTraceEnabled()) {
+          PsiElement element = (PsiElement)o;
+          int dumplevel = "IntellijIdeaRulezzz".equals(element.getText()) ? 5 : 2;
+          PsiElement superParent = HaxeDebugPsiUtil.getParents((PsiElement)o, dumplevel, false);
+          LOG.trace(HaxeDebugPsiUtil.printElementTree(superParent));
+        }
+      }
+      return matches;
+    }
+  }
 }

--- a/src/common/com/intellij/plugins/haxe/util/HaxeDebugPsiUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeDebugPsiUtil.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 20018 Eric Bishton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.impl.DebugUtil;
+import org.apache.log4j.Level;
+
+import java.util.Stack;
+
+public class HaxeDebugPsiUtil {
+
+  public static PsiElement getParents(PsiElement element, int level, boolean stopAtFile) {
+    if (element == null) return null;
+    if (level < 0) return null;
+    if (level == 0) return element;
+
+    PsiElement parent = element;
+    while (level-- > 0 && !(stopAtFile && parent instanceof PsiFile)) {
+      PsiElement p = parent.getParent();
+      if (null == p) { // Gives back the last good parent.
+        break;
+      }
+      parent = p;
+    }
+    return parent;
+  }
+
+  public static void dumpElementPath(PsiElement element) {
+    dumpElementPath(createLogger(HaxeDebugUtil.getCallerCanonicalName()), element);
+  }
+
+  public static void dumpElementPath(HaxeDebugLogger log, PsiElement element) {
+    if (null == log) {
+      log = createLogger(HaxeDebugUtil.getCallerCanonicalName());
+    }
+    if (log.isDebugEnabled()) {
+      log.debug(formatElementPath(element, false));
+    }
+  }
+
+  public static String printElementTree(PsiElement root) {
+    if (null == root) return "<NULL>";
+    return DebugUtil.psiToString(root, false);
+  }
+
+  public static String formatElementPath(PsiElement element, boolean includeDirectories) {
+    Stack<PsiElement> elements = new Stack<>();
+    while (null != element) {
+      if (!includeDirectories && element instanceof PsiFile) {
+        break;
+      }
+      elements.push(element);
+      element = element.getParent();
+    }
+
+    StringBuilder s = new StringBuilder();
+    int indent = 0;
+    while (!elements.isEmpty()) {
+      for (int j = 0; j < indent; j++) {
+        s.append("->");
+      }
+      indent++;
+
+      element = elements.pop();
+      s.append(element.getClass().getName());
+      s.append('\n');
+    }
+    return s.toString();
+  }
+
+  private static HaxeDebugLogger createLogger(String loggerName) {
+    HaxeDebugLogger log = HaxeDebugLogger.getLogger(loggerName);
+    log.setLevel(Level.DEBUG);
+    return log;
+  }
+}


### PR DESCRIPTION
When ':' is used in a position where a type is expected, the completion dropdown should appear.  In other places where ':' is used, (switch statements) it should not appear.

This also includes some debugging code for Completion patterns.