### PR TITLE
Auto-setup Haxe SDK

### DIFF
--- a/common/src/com/intellij/plugins/haxe/util/HaxeSdkUtilBase.java
+++ b/common/src/com/intellij/plugins/haxe/util/HaxeSdkUtilBase.java
@@ -72,7 +72,7 @@ public class HaxeSdkUtilBase {
   }
 
   public static String getExecutableName(String name) {
-    if (SystemInfo.isWindows) {
+    if (SystemInfo.isWindows && !name.endsWith(".exe")) {
       return name + ".exe";
     }
     return name;

--- a/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkType.java
+++ b/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkType.java
@@ -17,9 +17,10 @@
  */
 package com.intellij.plugins.haxe.config.sdk;
 
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.fileChooser.FileChooserDescriptor;
-import com.intellij.openapi.fileChooser.PathChooserDialog;
 import com.intellij.openapi.projectRoots.*;
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
 import com.intellij.openapi.roots.JavadocOrderRootType;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.util.SystemInfo;
@@ -120,5 +121,18 @@ public class HaxeSdkType extends SdkType {
       result.withShowHiddenFiles(true); // TODO: Test on a mac: converted for v15.
     }
     return result;
+  }
+
+  /**
+   * Try to automatically setup Haxe SDK if it's not configured yet.
+   */
+  public void ensureSdk() {
+    ProjectJdkTable sdkTable = ProjectJdkTable.getInstance();
+    if(sdkTable.getSdksOfType(this).isEmpty()) {
+      String homePath = HaxeSdkUtil.suggestHomePath();
+      Sdk sdk = new ProjectJdkImpl(getName(), this, homePath, getVersionString(homePath));
+      setupSdkPaths(sdk);
+      ApplicationManager.getApplication().runWriteAction(() -> sdkTable.addJdk(sdk));
+    }
   }
 }

--- a/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkType.java
+++ b/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkType.java
@@ -130,9 +130,11 @@ public class HaxeSdkType extends SdkType {
     ProjectJdkTable sdkTable = ProjectJdkTable.getInstance();
     if(sdkTable.getSdksOfType(this).isEmpty()) {
       String homePath = HaxeSdkUtil.suggestHomePath();
-      Sdk sdk = new ProjectJdkImpl(getName(), this, homePath, getVersionString(homePath));
-      setupSdkPaths(sdk);
-      ApplicationManager.getApplication().runWriteAction(() -> sdkTable.addJdk(sdk));
+      if(homePath != null) {
+        Sdk sdk = new ProjectJdkImpl(getName(), this, homePath, getVersionString(homePath));
+        setupSdkPaths(sdk);
+        ApplicationManager.getApplication().runWriteAction(() -> sdkTable.addJdk(sdk));
+      }
     }
   }
 }

--- a/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
+++ b/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
@@ -77,7 +77,7 @@ public class HaxeSdkUtil extends HaxeSdkUtilBase {
       }
       final HaxeSdkData haxeSdkData = new HaxeSdkData(path, haxeVersion);
       haxeSdkData.setHaxelibPath(getHaxelibPathByFolderPath(path));
-      haxeSdkData.setNekoBinPath(locateExecutable("neko"));
+      haxeSdkData.setNekoBinPath(suggestNekoBinPath(path));
       return haxeSdkData;
     }
     catch (ExecutionException e) {
@@ -115,6 +115,7 @@ public class HaxeSdkUtil extends HaxeSdkUtilBase {
     }
   }
 
+  @Nullable
   private static String suggestNekoBinPath(@NotNull String path) {
     String result = System.getenv("NEKOPATH");
     if (result == null) {

--- a/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
+++ b/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
@@ -184,10 +184,11 @@ public class HaxeSdkUtil extends HaxeSdkUtilBase {
    */
   @Nullable
   private static String locateExecutable(String executable) {
+    executable = getExecutableName(executable);
     String pathEnv = System.getenv("PATH");
     String[] paths = pathEnv.split(SystemInfo.isWindows ? ";" : ":");
     for(String path:paths) {
-      File file = new File(path, getExecutableName(executable));
+      File file = new File(path, executable);
       if(file.exists()) {
         try {
           return file.getCanonicalPath();

--- a/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
+++ b/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
@@ -117,39 +117,26 @@ public class HaxeSdkUtil extends HaxeSdkUtilBase {
 
   @Nullable
   private static String suggestNekoBinPath(@NotNull String path) {
-    String result = System.getenv("NEKOPATH");
-    if (result == null) {
-      result = System.getenv("NEKO_INSTPATH");
+    final String binName = "neko";
+    String result = null;
+
+    String nekoDir = System.getenv("NEKOPATH");
+    if (nekoDir == null) {
+      nekoDir = System.getenv("NEKO_INSTPATH");
     }
-    if (result == null && !SystemInfo.isWindows) {
-      final VirtualFile candidate = VirtualFileManager.getInstance().findFileByUrl("/usr/bin/neko");
-      if (candidate != null && candidate.exists()) {
-        String s = FileUtil.toSystemIndependentName(candidate.getPath());
-        LOG.debug("returning neko path: " + s);
-        return s;
+    if(nekoDir != null) {
+      File nekoFile =  new File(nekoDir, binName);
+      if(nekoFile.exists()) {
+        result = nekoFile.getPath();
       }
     }
-    if (result == null) {
-      final String parentPath = new File(path).getParent();
-      result = new File(parentPath, "neko").getAbsolutePath();
-    }
-    if (result != null) {
-      result = new File(result, getExecutableName("neko")).getAbsolutePath();
-    }
-    if (result != null && new File(result).exists()) {
-      String s = FileUtil.toSystemIndependentName(result);
-      LOG.debug("returning neko path: " + s);
-      return s;
+
+    if(result == null) {
+      result = locateExecutable(binName);
     }
 
-    result = locateExecutable("neko");
-    if(result != null) {
-      LOG.debug("returning neko path: " + result);
-      return result;
-    }
-
-    LOG.debug("returning neko path: null");
-    return null;
+    LOG.debug("returning neko path: " + String.valueOf(result));
+    return result;
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleType.java
+++ b/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleType.java
@@ -19,19 +19,13 @@ package com.intellij.plugins.haxe.ide.module;
 
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleTypeManager;
-import com.intellij.openapi.projectRoots.ProjectJdkTable;
-import com.intellij.openapi.projectRoots.Sdk;
-import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.plugins.haxe.HaxeBundle;
 import com.intellij.plugins.haxe.config.sdk.HaxeSdkType;
-import com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil;
 
 import javax.swing.*;
-import java.util.List;
 
 public class HaxeModuleType extends ModuleType<HaxeModuleBuilder> {
   private static final String MODULE_TYPE_ID = "HAXE_MODULE";
@@ -75,14 +69,7 @@ public class HaxeModuleType extends ModuleType<HaxeModuleBuilder> {
                                               final ModulesProvider modulesProvider) {
 
     HaxeSdkType type = HaxeSdkType.getInstance();
-
-    ProjectJdkTable sdkTable = ProjectJdkTable.getInstance();
-    if(sdkTable.getSdksOfType(type).isEmpty()) {
-      String homePath = HaxeSdkUtil.suggestHomePath();
-      Sdk sdk = new ProjectJdkImpl(type.getName(), type, homePath, type.getVersionString(homePath));
-      type.setupSdkPaths(sdk);
-      ApplicationManager.getApplication().runWriteAction(() -> sdkTable.addJdk(sdk));
-    }
+    type.ensureSdk();
 
     return new ModuleWizardStep[]{
       new HaxeSdkWizardStep(moduleBuilder, wizardContext, type)

--- a/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleType.java
+++ b/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleType.java
@@ -67,7 +67,6 @@ public class HaxeModuleType extends ModuleType<HaxeModuleBuilder> {
   public ModuleWizardStep[] createWizardSteps(final WizardContext wizardContext,
                                               final HaxeModuleBuilder moduleBuilder,
                                               final ModulesProvider modulesProvider) {
-
     HaxeSdkType type = HaxeSdkType.getInstance();
     type.ensureSdk();
 

--- a/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleType.java
+++ b/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleType.java
@@ -18,15 +18,20 @@
 package com.intellij.plugins.haxe.ide.module;
 
 import com.intellij.ide.util.projectWizard.ModuleWizardStep;
-import com.intellij.ide.util.projectWizard.ProjectJdkForModuleStep;
 import com.intellij.ide.util.projectWizard.WizardContext;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleTypeManager;
+import com.intellij.openapi.projectRoots.ProjectJdkTable;
+import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
 import com.intellij.openapi.roots.ui.configuration.ModulesProvider;
 import com.intellij.plugins.haxe.HaxeBundle;
 import com.intellij.plugins.haxe.config.sdk.HaxeSdkType;
+import com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil;
 
 import javax.swing.*;
+import java.util.List;
 
 public class HaxeModuleType extends ModuleType<HaxeModuleBuilder> {
   private static final String MODULE_TYPE_ID = "HAXE_MODULE";
@@ -68,8 +73,19 @@ public class HaxeModuleType extends ModuleType<HaxeModuleBuilder> {
   public ModuleWizardStep[] createWizardSteps(final WizardContext wizardContext,
                                               final HaxeModuleBuilder moduleBuilder,
                                               final ModulesProvider modulesProvider) {
+
+    HaxeSdkType type = HaxeSdkType.getInstance();
+
+    ProjectJdkTable sdkTable = ProjectJdkTable.getInstance();
+    if(sdkTable.getSdksOfType(type).isEmpty()) {
+      String homePath = HaxeSdkUtil.suggestHomePath();
+      Sdk sdk = new ProjectJdkImpl(type.getName(), type, homePath, type.getVersionString(homePath));
+      type.setupSdkPaths(sdk);
+      ApplicationManager.getApplication().runWriteAction(() -> sdkTable.addJdk(sdk));
+    }
+
     return new ModuleWizardStep[]{
-      new HaxeSdkWizardStep(moduleBuilder, wizardContext, HaxeSdkType.getInstance())
+      new HaxeSdkWizardStep(moduleBuilder, wizardContext, type)
     };
   }
 }


### PR DESCRIPTION
* Automatically setup Haxe SDK on "Create new project" If it's not configured yet;
* Fixed locating SDK classes and sources in case if `HAXE_STD_PATH` env var is defined;
* Fixed locating neko executable path if no special env var is configured;
* Fixed locating Haxe SDK root path if no special env var is configured;