### PR TITLE
Auto-setup Haxe SDK on "Import project from source"

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/projectStructure/detection/HaxeProjectStructureDetector.java
+++ b/src/common/com/intellij/plugins/haxe/ide/projectStructure/detection/HaxeProjectStructureDetector.java
@@ -89,7 +89,9 @@ public class HaxeProjectStructureDetector extends ProjectStructureDetector {
       new LibrariesDetectionStep(builder, projectDescriptor, moduleInsight, stepIcon, "reference.dialogs.new.project.fromCode.page1"));
     steps.add(
       new ModulesDetectionStep(this, builder, projectDescriptor, moduleInsight, stepIcon, "reference.dialogs.new.project.fromCode.page2"));
-    steps.add(new ProjectJdkForModuleStep(builder.getContext(), HaxeSdkType.getInstance()));
+    HaxeSdkType type = HaxeSdkType.getInstance();
+    type.ensureSdk();
+    steps.add(new ProjectJdkForModuleStep(builder.getContext(), type));
     return steps;
   }
 


### PR DESCRIPTION
This PR complements #856 
Automatically detect and setup Haxe SDK on "Import project from source" if Haxe SDK is not configured yet.