### PR TITLE
Automatically add super call to the generated override methods

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/generation/OverrideImplementMethodFix.java
+++ b/src/common/com/intellij/plugins/haxe/ide/generation/OverrideImplementMethodFix.java
@@ -84,7 +84,7 @@ public class OverrideImplementMethodFix extends BaseCreateMethodsFix<HaxeNamedCo
       result.append(";");
     } else {
       result.append("{\n");
-      if(addOverride) {
+      if(addOverride || element.isOverride()) {
         if(type != null && !type.equals("Void")) {
           result.append("return ");
         }

--- a/src/common/com/intellij/plugins/haxe/ide/generation/OverrideImplementMethodFix.java
+++ b/src/common/com/intellij/plugins/haxe/ide/generation/OverrideImplementMethodFix.java
@@ -49,7 +49,8 @@ public class OverrideImplementMethodFix extends BaseCreateMethodsFix<HaxeNamedCo
     final PsiClass containingClass = element instanceof PsiMember ? ((PsiMember)element).getContainingClass() : null;
     final boolean isInterfaceElement = containingClass != null && containingClass.isInterface();
 
-    if (!isInterfaceElement && override && !element.isOverride()) {
+    boolean addOverride = !isInterfaceElement && override && !element.isOverride();
+    if (addOverride) {
       result.append("override ");
     }
     final HaxePsiModifier[] declarationAttributeList = PsiTreeUtil.getChildrenOfType(element, HaxePsiModifier.class);
@@ -70,17 +71,36 @@ public class OverrideImplementMethodFix extends BaseCreateMethodsFix<HaxeNamedCo
       result.append(element.getName());
     } else {
       result.append("function ");
-      result.append(element.getName());
-      result.append(" (");
-      result.append(HaxePresentableUtil.getPresentableParameterList(element, specializations));
-      result.append(")");
+      appendMethodNameAndParameters(result, element, true);
     }
     final HaxeTypeTag typeTag = PsiTreeUtil.getChildOfType(element, HaxeTypeTag.class);
+    String type = null;
     if (typeTag != null && typeTag.getTypeOrAnonymous() != null) {
       result.append(":");
-      result.append(HaxePresentableUtil.buildTypeText(element, typeTag.getTypeOrAnonymous().getType(), specializations));
+      type = HaxePresentableUtil.buildTypeText(element, typeTag.getTypeOrAnonymous().getType(), specializations);
+      result.append(type);
     }
-    result.append(componentType == HaxeComponentType.FIELD ? ";" : "{\n}");
+    if(componentType == HaxeComponentType.FIELD) {
+      result.append(";");
+    } else {
+      result.append("{\n");
+      if(addOverride) {
+        if(type != null && !type.equals("Void")) {
+          result.append("return ");
+        }
+        result.append("super.");
+        appendMethodNameAndParameters(result, element, false);
+        result.append(";\n");
+      }
+      result.append("}");
+    }
     return result.toString();
+  }
+
+  private void appendMethodNameAndParameters(StringBuilder buf, HaxeNamedComponent element, boolean addParametersTypes) {
+    buf.append(element.getName());
+    buf.append(" (");
+    buf.append(HaxePresentableUtil.getPresentableParameterList(element, specializations, addParametersTypes));
+    buf.append(")");
   }
 }

--- a/src/common/com/intellij/plugins/haxe/util/HaxePresentableUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxePresentableUtil.java
@@ -59,11 +59,11 @@ public class HaxePresentableUtil {
 
   @NotNull
   public static String getPresentableParameterList(HaxeNamedComponent element) {
-    return getPresentableParameterList(element, new HaxeGenericSpecialization());
+    return getPresentableParameterList(element, new HaxeGenericSpecialization(), true);
   }
 
   @NotNull
-  public static String getPresentableParameterList(HaxeNamedComponent element, HaxeGenericSpecialization specialization) {
+  public static String getPresentableParameterList(HaxeNamedComponent element, HaxeGenericSpecialization specialization, boolean addTypes) {
     final StringBuilder result = new StringBuilder();
     final HaxeParameterListPsiMixinImpl parameterList = PsiTreeUtil.getChildOfType(element, HaxeParameterListPsiMixinImpl.class);
     if (parameterList == null) {
@@ -73,7 +73,7 @@ public class HaxePresentableUtil {
     for (int i = 0, size = list.size(); i < size; i++) {
       HaxeParameter parameter = list.get(i);
       result.append(parameter.getName());
-      if (parameter.getTypeTag() != null) {
+      if (addTypes && parameter.getTypeTag() != null) {
         result.append(":");
         result.append(buildTypeText(parameter, parameter.getTypeTag(), specialization));
       }

--- a/testData/generate/Override1.txt
+++ b/testData/generate/Override1.txt
@@ -1,6 +1,7 @@
 class Override1 extends Foo<Bar> {
 
     override public function getFoo():Bar {
+        return super.getFoo();
     }
 }
 

--- a/testData/generate/Override2.txt
+++ b/testData/generate/Override2.txt
@@ -1,9 +1,11 @@
 class A extends B {
 
     override public function a():Void {
+        super.a();
     }
 
     override public function d() {
+        super.d();
     }
 }
 


### PR DESCRIPTION
Currently "Override methods... ^O" generates code like this:
```haxe
override public function test(arg1:Int):Void {
}
```
This PR adds the `super` call:
```haxe
override public function test(arg1:Int):Void {
  super.test(arg1);
}
```
or with non-Void return type:
```haxe
override public function test(arg1:Int):String {
  return super.test(arg1);
}
```