### PR TITLE
Automatically change references to the moved class.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -532,7 +532,7 @@ applying your changes against the master branch.
 6. Create a pull request, and wait for comments.
 7. If you get comments that require changes, address those and return to step 2.
 8. When you get an “OK to merge,” or "approved," message from anyone on the team: Eric, @EricBishton; Ilya Malanin, @Mayakwd; Boyan, @as3boyan;
-or Ilya Kuzmenko, @EliasKu (others as they become regular contributors,) go ahead
+or Ilya Kuzmichev, @EliasKu (others as they become regular contributors,) go ahead
 and merge your changes to master.  A clean merge requires no further testing,
 as Travis-ci will do it for you.  However any build break must be addressed immediately.  A build
 that has conflicts requires manual resolution and must be re-tested locally prior to push.  For regular

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -4,6 +4,7 @@
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2018 Eric Bishton
  * Copyright 2017-2018 Ilya Malanin
+ * Copyright 2018 Aleksandr Kuzmenko
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -532,7 +533,24 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
   }
 
   private void bindToClass(PsiClass element) {
-    handleElementRename(element.getName());
+    String ref = getReferenceName();
+    //The name was not changed. Are we moving a class to another package?
+    if(element instanceof HaxeClassDeclaration && ref != null && ref.equals(element.getName())) {
+      handleClassMovement(element);
+    //rename
+    } else {
+      handleElementRename(element.getName());
+    }
+  }
+
+  private void handleClassMovement(PsiClass element) {
+    String thisFqn = getQualifiedName();
+    //This is reference is not a fully qualified name. Nothing to do.
+    if(!thisFqn.contains(".")) {
+      return;
+    }
+    String newFqn = ((HaxeClassDeclaration)element).getModel().haxeClass.getQualifiedName();
+    updateFullyQualifiedReference(newFqn);
   }
 
   private void bindToPackage(PsiPackage element) {

--- a/testData/move/moveClass/after/Test.hx
+++ b/testData/move/moveClass/after/Test.hx
@@ -1,0 +1,13 @@
+package ;
+
+import pack2.Moved;
+
+using pack2.Moved;
+
+class Test {
+    static function main() {
+        trace(Moved.test(10));
+        trace(pack2.Moved.test(10));
+        trace(10.test());
+    }
+}

--- a/testData/move/moveClass/after/pack2/Moved.hx
+++ b/testData/move/moveClass/after/pack2/Moved.hx
@@ -1,0 +1,6 @@
+package pack2;
+class Moved {
+  static public function test(v:Int) {
+    return v;
+  }
+}

--- a/testData/move/moveClass/before/Test.hx
+++ b/testData/move/moveClass/before/Test.hx
@@ -1,0 +1,13 @@
+package ;
+
+import pack1.Moved;
+
+using pack1.Moved;
+
+class Test {
+    static function main() {
+        trace(Moved.test(10));
+        trace(pack1.Moved.test(10));
+        trace(10.test());
+    }
+}

--- a/testData/move/moveClass/before/pack1/Moved.hx
+++ b/testData/move/moveClass/before/pack1/Moved.hx
@@ -1,0 +1,6 @@
+package pack1;
+class Moved {
+  static public function test(v:Int) {
+    return v;
+  }
+}


### PR DESCRIPTION
Currently moving a class across packages does not change the references, which hold a fully qualified class name. 
E.g. if `pack1.Test` is moved to `pack2.Test`, then the following code is left unchanged, thus invalid:
```haxe
import pack1.Test;

using pack1.Test;

class Main {
    static public function main() {
        pack1.Test.test(10);
        Test.test(10);
        10.test();
    }
}
```
This PR fixes moving classes across packages. And the above example becomes:
```haxe
import pack2.Test;

using pack2.Test;

class Main {
    static public function main() {
        pack2.Test.test(10);
        Test.test(10);
        10.test();
    }
}
```
Unfortunately I couldn't figure out how to create a test for this.  I've added the test data (before/after the refactoring) and would appreciate if somebody gives me a hint on how to create a test.