### PR TITLE
Fixed NPE occurring while resolving of module libraries.

### DIFF
--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
@@ -223,6 +223,7 @@ public class HaxelibUtil {
       entries.forEachLibrary(new Processor<Library>() {
         @Override
         public boolean process(Library library) {
+          if (library == null || library.getName() == null) return true;
           HaxeLibraryReference ref = HaxeLibraryReference.create(module, library.getName());
           if (null != ref) {
             moduleLibs.add(ref);
@@ -260,6 +261,8 @@ public class HaxelibUtil {
     Library[] libraries = libraryTable.getLibraries();
     for (Library library : libraries) {
       String name = library.getName();
+      if (name == null) continue;
+
       boolean isManaged = HaxelibNameUtil.isManagedLibrary(name);
       if (filterManagedLibs && isManaged) continue;
       if (filterUnmanagedLibs && !isManaged) continue;


### PR DESCRIPTION
Got report from user:

```
java.lang.RuntimeException: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'name' of com/intellij/plugins/haxe/haxelib/HaxeLibraryReference.create must not be null
	at com.intellij.openapi.application.impl.LaterInvocator.invokeAndWait(LaterInvocator.java:179)
	at com.intellij.openapi.application.impl.ApplicationImpl.invokeAndWait(ApplicationImpl.java:660)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater.doReadAction(HaxelibProjectUpdater.java:1044)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater.syncModuleClasspaths(HaxelibProjectUpdater.java:702)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater.synchronizeClasspaths(HaxelibProjectUpdater.java:744)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater.access$800(HaxelibProjectUpdater.java:84)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater$ProjectUpdateQueue.doUpdateWork(HaxelibProjectUpdater.java:1567)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater$ProjectUpdateQueue.access$700(HaxelibProjectUpdater.java:1408)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater$ProjectUpdateQueue$3$1.run(HaxelibProjectUpdater.java:1549)
	at com.intellij.openapi.progress.impl.CoreProgressManager$TaskRunnable.run(CoreProgressManager.java:736)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:157)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:580)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:525)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:85)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:144)
	at com.intellij.openapi.progress.impl.CoreProgressManager$4.run(CoreProgressManager.java:395)
	at com.intellij.openapi.application.impl.ApplicationImpl$1.run(ApplicationImpl.java:314)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.lang.IllegalArgumentException: Argument for @NotNull parameter 'name' of com/intellij/plugins/haxe/haxelib/HaxeLibraryReference.create must not be null
	at com.intellij.plugins.haxe.haxelib.HaxeLibraryReference.$$$reportNull$$$0(HaxeLibraryReference.java)
	at com.intellij.plugins.haxe.haxelib.HaxeLibraryReference.create(HaxeLibraryReference.java)
	at com.intellij.plugins.haxe.haxelib.HaxelibUtil$1.process(HaxelibUtil.java:226)
	at com.intellij.plugins.haxe.haxelib.HaxelibUtil$1.process(HaxelibUtil.java:223)
	at com.intellij.openapi.roots.impl.OrderEnumeratorBase.lambda$forEachLibrary$1(OrderEnumeratorBase.java:340)
	at com.intellij.openapi.roots.impl.OrderEnumeratorBase.processEntries(OrderEnumeratorBase.java:303)
	at com.intellij.openapi.roots.impl.ModuleOrderEnumerator.forEach(ModuleOrderEnumerator.java:47)
	at com.intellij.openapi.roots.impl.OrderEnumeratorBase.forEachLibrary(OrderEnumeratorBase.java:336)
	at com.intellij.openapi.roots.impl.ModuleOrderEnumerator.forEachLibrary(ModuleOrderEnumerator.java:32)
	at com.intellij.plugins.haxe.haxelib.HaxelibUtil.getModuleLibraries(HaxelibUtil.java:223)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater.resolveModuleLibraries(HaxelibProjectUpdater.java:242)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater.syncOneModule(HaxelibProjectUpdater.java:674)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater.access$500(HaxelibProjectUpdater.java:84)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater$5.run(HaxelibProjectUpdater.java:705)
	at com.intellij.openapi.application.impl.ApplicationImpl.runReadAction(ApplicationImpl.java:925)
	at com.intellij.plugins.haxe.haxelib.HaxelibProjectUpdater$14.run(HaxelibProjectUpdater.java:1047)
	at com.intellij.openapi.application.TransactionGuardImpl$2.run(TransactionGuardImpl.java:315)
	at com.intellij.openapi.application.impl.LaterInvocator$1.run(LaterInvocator.java:156)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.doRun(LaterInvocator.java:447)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.runNextEvent(LaterInvocator.java:431)
	at com.intellij.openapi.application.impl.LaterInvocator$FlushQueue.run(LaterInvocator.java:415)
	at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
	at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:762)
	at java.awt.EventQueue.access$500(EventQueue.java:98)
	at java.awt.EventQueue$3.run(EventQueue.java:715)
	at java.awt.EventQueue$3.run(EventQueue.java:709)
	at java.security.AccessController.doPrivileged(Native Method)
	at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:80)
	at java.awt.EventQueue.dispatchEvent(EventQueue.java:732)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:781)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:722)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:382)
	at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:201)
	at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
	at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
	at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```