### PR TITLE
Resolution fixes for generics, typedefs, and array access:

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -2,7 +2,7 @@
   ~ Copyright 2000-2013 JetBrains s.r.o.
   ~ Copyright 2014-2014 AS3Boyan
   ~ Copyright 2014-2014 Elias Ku
-  ~ Copyright 2017 Eric Bishton
+  ~ Copyright 2017-2018 Eric Bishton
   ~ Copyright 2017-2018 Ilya Malanin
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -82,6 +82,10 @@
       <p/>
       <p>Unreleased changes</p>
       <ul>
+        <li>Now resolves typedefs to underlying types. (e.g. `var v:Null<String>` is resolved as a `String` type.)</li>
+        <li>Now propagates type parameters (generics) properly through typedefs.</li>
+        <li>Now resolves types when used with array access (e.g. `map[0].length` no longer marked as errors).</li>
+        <li>Now infers types of methods without specific typing (e.g. `map.get(0).length` no longer marked as errors).</li>
         <li>Inspections for non-haxe files disabled.</li>
         <li>Fixed recognizing type of "this" expression.</li>
         <li>Fixed bug when physical variables were marked as not real.</li>

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoHandler.java
@@ -3,6 +3,7 @@
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2017 Ilya Malanin
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +25,7 @@ import com.intellij.openapi.util.Condition;
 import com.intellij.plugins.haxe.HaxeComponentType;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
 import com.intellij.plugins.haxe.model.type.HaxeTypeResolver;
 import com.intellij.plugins.haxe.model.type.ResultHolder;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
@@ -246,7 +248,8 @@ public class HaxeParameterInfoHandler implements ParameterInfoHandler<PsiElement
       final HaxeExpression argument = arguments.get(argumentIndex);
 
       final ResultHolder parameterType = parameter.getResultHolder();
-      final ResultHolder argumentType = HaxeTypeResolver.getPsiElementType(argument);
+      // TODO: Probably should be using a correct specialization here, instead of a blank resolver.
+      final ResultHolder argumentType = HaxeTypeResolver.getPsiElementType(argument, new HaxeGenericResolver());
 
       if (parameterType.canAssign(argumentType)) {
         if (argumentIndex == currentArgumentIndex) return parameterIndex;

--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeClassResolveResult.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeClassResolveResult.java
@@ -254,7 +254,7 @@ public class HaxeClassResolveResult implements Cloneable {
   }
 
   /**
-   * Creates a resolved parameter list that can be used with specializedByParameters() when resolving
+   * Creates a resolved parameter list that can be used with specializeByParameters() when resolving
    * subclasses.
    *
    * @param targetParam - the haxe class that is being resolved

--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeGenericSpecialization.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeGenericSpecialization.java
@@ -2,7 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
- * Copyright 2017 Eric Bishton
+ * Copyright 2017-2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,12 @@
  */
 package com.intellij.plugins.haxe.lang.psi;
 
+import com.intellij.plugins.haxe.model.HaxeClassModel;
+import com.intellij.plugins.haxe.model.type.*;
+import com.intellij.plugins.haxe.util.HaxeDebugUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.PsiTreeUtil;
 import gnu.trove.THashMap;
-import gnu.trove.TObjectObjectProcedure;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -31,7 +33,14 @@ import java.util.Map;
  * @author: Fedor.Korotkov
  */
 public class HaxeGenericSpecialization implements Cloneable {
-  public static final HaxeGenericSpecialization EMPTY = new HaxeGenericSpecialization();
+
+  public static final HaxeGenericSpecialization EMPTY = new HaxeGenericSpecialization() {
+    @Override
+    public void put(PsiElement element, String genericName, HaxeClassResolveResult resolveResult) {
+      throw new HaxeDebugUtil.InvalidValueException("Must not modify (shared) EMPTY specialization.");
+    }
+  };
+
   final Map<String, HaxeClassResolveResult> map;
 
   public HaxeGenericSpecialization() {
@@ -49,6 +58,54 @@ public class HaxeGenericSpecialization implements Cloneable {
 
   protected HaxeGenericSpecialization(Map<String, HaxeClassResolveResult> map) {
     this.map = map;
+  }
+
+  /**
+   * @return the values in this specialization as a HaxeGenericResolver.
+   **/
+  public HaxeGenericResolver toGenericResolver(@Nullable PsiElement element) {
+    /*
+     * Optimally, this method would be part of the model layer (which uses HaxeGenericResolvers),
+     * rather than part of this one, but that forces us to leak the details of how keys are created
+     * and stored.
+     *
+     * Another thought is to make the HaxeGenericResolver be a sub-class of this one.
+     *
+     * A third would be to remove HaxeGenericResolver altogether and make the models use this class.
+     */
+    if (null != element) {
+      return getInnerSpecialization(element).toGenericResolver(null);
+    }
+
+    HaxeGenericResolver resolver = new HaxeGenericResolver();
+    for (String key : map.keySet()) {
+      // Get and convert the resolveResults into ResultHolders,
+      HaxeClass parameterClass = map.get(key).getHaxeClass();
+      HaxeClassModel model = HaxeClassModel.fromElement(parameterClass);
+      if (null != parameterClass && null != model) {
+        HaxeClassReference reference = new HaxeClassReference(model, parameterClass);
+        ResultHolder holder = SpecificHaxeClassReference.withoutGenerics(reference).createHolder();
+        resolver.add(key, holder);
+      } // TODO: else create a reference to Dynamic or Any??
+    }
+    return resolver;
+  }
+
+  @NotNull
+  public static HaxeGenericSpecialization fromGenericResolver(@NotNull PsiElement element, @Nullable HaxeGenericResolver resolver) {
+    HaxeGenericSpecialization specialization = new HaxeGenericSpecialization();
+    if (null != resolver) {
+      for (String name : resolver.names()) {
+        ResultHolder holder = resolver.resolve(name);
+        PsiElement held = holder.getElementContext();
+        if (held instanceof HaxeClass) {
+          HaxeClassResolveResult resolved =
+            HaxeClassResolveResult.create((HaxeClass)held, fromGenericResolver(held, holder.getClassType().getGenericResolver()));
+          specialization.put(element, name, resolved);
+        }
+      }
+    }
+    return specialization;
   }
 
   public void put(PsiElement element, String genericName, HaxeClassResolveResult resolveResult) {
@@ -73,6 +130,7 @@ public class HaxeGenericSpecialization implements Cloneable {
     return map.get(getGenericKey(element, genericName));
   }
 
+  @NotNull
   public HaxeGenericSpecialization getInnerSpecialization(PsiElement element) {
     final String prefixToRemove = getGenericKey(element, "");
     final Map<String, HaxeClassResolveResult> result = new THashMap<String, HaxeClassResolveResult>();

--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeMethodPsiMixin.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeMethodPsiMixin.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,5 +25,8 @@ import com.intellij.psi.PsiMethod;
  * Created by ebishton on 9/28/14.
  */
 public interface HaxeMethodPsiMixin extends PsiMethod, HaxeNamedComponent {
+
   HaxeMethodModel getModel();
+
+  HaxeGenericParam getGenericParam();
 }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeTypePsiMixin.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeTypePsiMixin.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,13 +19,12 @@
 package com.intellij.plugins.haxe.lang.psi;
 
 import com.intellij.psi.PsiType;
-import com.intellij.psi.PsiTypeParameterListOwner;
 import org.jetbrains.annotations.Nullable;
 
 /**
  * Created by ebishton on 10/9/14.
  */
-public interface HaxeTypePsiMixin extends HaxePsiCompositeElement, PsiTypeParameterListOwner {
+public interface HaxeTypePsiMixin extends HaxePsiCompositeElement { //, PsiTypeParameterListOwner {
 
   /**
    * Gets the (Java) PsiType (Actually the HaxePsiTypeAdapter) that

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodImpl.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +28,7 @@ import com.intellij.plugins.haxe.lang.psi.HaxeMethod;
  * Created by ebishton on 9/28/14.
  */
 public abstract class HaxeMethodImpl extends HaxeMethodPsiMixinImpl implements HaxeMethod {
-  public HaxeMethodImpl(ASTNode node) {
+  protected HaxeMethodImpl(ASTNode node) {
     super(node);
   }
 }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -4,6 +4,7 @@
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2018 Ilya Malanin
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,13 +48,15 @@ import java.util.List;
  */
 public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent implements HaxeMethodPsiMixin {
 
+  // TODO: Merge this PsiMixin class(and interface) with HaxeMethod.  There is no reason to keep both, or that this be named 'mixin'.
+
   private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodPsiMixinImpl");
   static {
     LOG.info("Loaded HaxeMethodPsiMixinImpl");
     LOG.setLevel(Level.DEBUG);
   }
 
-  public HaxeMethodPsiMixinImpl(ASTNode node) {
+  protected HaxeMethodPsiMixinImpl(ASTNode node) {
     super(node);
   }
 
@@ -78,11 +81,11 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
 
   private HaxeMethodModel _model = null;
   public HaxeMethodModel getModel() {
-    if (_model == null) _model = new HaxeMethodModel(this);
+    if (_model == null) {
+      _model = new HaxeMethodModel((HaxeMethod)this);
+    }
     return _model;
   }
-
-
 
   @Nullable
   public HaxeReturnStatement getReturnStatement() {
@@ -345,4 +348,7 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
     }
     return super.getUseScope();
   }
+
+  @Nullable
+  public abstract HaxeGenericParam getGenericParam();
 }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiTypeAdapter.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiTypeAdapter.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,48 +73,48 @@ public class HaxePsiTypeAdapter extends PsiType implements HaxeType {
   //
   // ParameterListOwner methods.
   //
-
-  @Override
-  public boolean hasTypeParameters() {
-    return myType.hasTypeParameters();
-  }
-
-  @Nullable
-  @Override
-  public PsiTypeParameterList getTypeParameterList() {
-    return myType.getTypeParameterList();
-  }
-
-  @NotNull
-  @Override
-  public PsiTypeParameter[] getTypeParameters() {
-    return myType.getTypeParameters();
-  }
+  //
+  //@Override
+  //public boolean hasTypeParameters() {
+  //  return myType.hasTypeParameters();
+  //}
+  //
+  //@Nullable
+  //@Override
+  //public PsiTypeParameterList getTypeParameterList() {
+  //  return myType.getTypeParameterList();
+  //}
+  //
+  //@NotNull
+  //@Override
+  //public PsiTypeParameter[] getTypeParameters() {
+  //  return myType.getTypeParameters();
+  //}
 
   //
   // PsiMember methods.
   //
-
-  @Nullable
-  @Override
-  public PsiClass getContainingClass() {
-    return myType.getContainingClass();
-  }
-
   //
-  // PsiModifierListOwner methods.
+  //@Nullable
+  //@Override
+  //public PsiClass getContainingClass() {
+  //  return myType.getContainingClass();
+  //}
   //
-
-  @Nullable
-  @Override
-  public PsiModifierList getModifierList() {
-    return myType.getModifierList();
-  }
-
-  @Override
-  public boolean hasModifierProperty(@PsiModifier.ModifierConstant @NonNls @NotNull String name) {
-    return myType.hasModifierProperty(name);
-  }
+  ////
+  //// PsiModifierListOwner methods.
+  ////
+  //
+  //@Nullable
+  //@Override
+  //public PsiModifierList getModifierList() {
+  //  return myType.getModifierList();
+  //}
+  //
+  //@Override
+  //public boolean hasModifierProperty(@PsiModifier.ModifierConstant @NonNls @NotNull String name) {
+  //  return myType.hasModifierProperty(name);
+  //}
 
 
   //

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -162,7 +162,7 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
   public boolean resolveIsStaticExtension() {
     // @TODO: DIRTY HACK! to avoid rewriting all the code!
     HaxeResolver.INSTANCE.resolve(this, true);
-    return HaxeResolver.isExtension.get();
+    return null != HaxeResolver.isExtension ? HaxeResolver.isExtension.get() : false;
   }
 
   @NotNull

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypePsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypePsiMixinImpl.java
@@ -3,6 +3,7 @@
  * Copyright 2014-2014 TiVo Inc.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +21,9 @@ package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.psi.*;
-import com.intellij.psi.impl.PsiImplUtil;
 import org.apache.log4j.Level;
-import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -49,37 +47,37 @@ public class HaxeTypePsiMixinImpl extends HaxePsiCompositeElementImpl implements
     return (this instanceof HaxeType) ? new HaxePsiTypeAdapter((HaxeType)this) : null;
   }
 
-  @Override
-  public boolean hasTypeParameters() {
-    return getTypeParameters().length != 0;
-  }
-
-  @Nullable
-  @Override
-  public PsiTypeParameterList getTypeParameterList() {
-    return (HaxeTypeParam) findChildByType(HaxeTokenTypes.TYPE_PARAM);
-  }
-
-  @NotNull
-  @Override
-  public PsiTypeParameter[] getTypeParameters() {
-    return PsiImplUtil.getTypeParameters(this);
-  }
-
-  @Nullable
-  @Override
-  public PsiClass getContainingClass() {
-    PsiElement parent = getParent();
-    while (parent != null) {
-      if (parent instanceof HaxeFile) {
-        // If we get to the file node, we've gone too far.
-        return null;
-      }
-      if (parent instanceof HaxeClass) {
-        return (HaxeClass)parent;
-      }
-      parent = parent.getParent();
-    }
-    return null;
-  }
+  //@Override
+  //public boolean hasTypeParameters() {
+  //  return getTypeParameters().length != 0;
+  //}
+  //
+  //@Nullable
+  //@Override
+  //public PsiTypeParameterList getTypeParameterList() {
+  //  return (HaxeTypeParam) findChildByType(HaxeTokenTypes.TYPE_PARAM);
+  //}
+  //
+  //@NotNull
+  //@Override
+  //public PsiTypeParameter[] getTypeParameters() {
+  //  return PsiImplUtil.getTypeParameters(this);
+  //}
+  //
+  //@Nullable
+  //@Override
+  //public PsiClass getContainingClass() {
+  //  PsiElement parent = getParent();
+  //  while (parent != null) {
+  //    if (parent instanceof HaxeFile) {
+  //      // If we get to the file node, we've gone too far.
+  //      return null;
+  //    }
+  //    if (parent instanceof HaxeClass) {
+  //      return (HaxeClass)parent;
+  //    }
+  //    parent = parent.getParent();
+  //  }
+  //  return null;
+  //}
 }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeGenericParamModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeGenericParamModel.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +18,11 @@
  */
 package com.intellij.plugins.haxe.model;
 
-import com.intellij.plugins.haxe.lang.psi.HaxeGenericListPart;
-import com.intellij.plugins.haxe.lang.psi.HaxeGenericParam;
+import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeNamedComponent;
+import com.intellij.plugins.haxe.model.type.*;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class HaxeGenericParamModel {
   final private HaxeGenericListPart part;
@@ -42,5 +45,34 @@ public class HaxeGenericParamModel {
 
   public HaxeGenericListPart getPsi() { return part; }
 
-  //public List<Object> getConstraints() { }
+  @Nullable
+  public ResultHolder getConstraint(@Nullable HaxeGenericResolver resolver) {
+    if (null == resolver) {
+      resolver = new HaxeGenericResolver();
+    }
+
+    HaxeTypeListPart constraint = part.getTypeListPart();
+    if (null != constraint) {
+      HaxeTypeOrAnonymous toa = constraint.getTypeOrAnonymous();
+      if (null != toa.getType()) {
+        HaxeReferenceExpression reference = toa.getType().getReferenceExpression();
+        if (null != reference) {
+
+          ResultHolder result =
+            HaxeExpressionEvaluator.evaluate(reference, new HaxeExpressionEvaluatorContext(part, null), resolver).result;
+          return result;
+        }
+        else {
+
+          // TODO: Deal with function return types.
+
+        }
+      }
+      else {
+        // Anonymous struct for a constraint.
+        // TODO: Turn the anonymous structure into a ResolveResult.
+      }
+    }
+    return null;
+  }
 }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
@@ -2,7 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
- * Copyright 2017 Eric Bishton
+ * Copyright 2017-2018 Eric Bishton
  * Copyright 2017-2018 Ilya Malanin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,9 +36,9 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class HaxeMethodModel extends HaxeMemberModel implements HaxeExposableModel {
-  private HaxeMethodPsiMixin haxeMethod;
+  private HaxeMethod haxeMethod;
 
-  public HaxeMethodModel(HaxeMethodPsiMixin haxeMethod) {
+  public HaxeMethodModel(HaxeMethod haxeMethod) {
     super(haxeMethod);
     this.haxeMethod = haxeMethod;
   }
@@ -171,6 +171,19 @@ public class HaxeMethodModel extends HaxeMemberModel implements HaxeExposableMod
   @Override
   public HaxeExposableModel getExhibitor() {
     return getDeclaringClass();
+  }
+
+  @Nullable
+  public List<HaxeGenericParamModel> getGenericParams() {
+    final List<HaxeGenericParamModel> out = new ArrayList<>();
+    if (haxeMethod.getGenericParam() != null) {
+      int index = 0;
+      for (HaxeGenericListPart part : haxeMethod.getGenericParam().getGenericListPartList()) {
+        out.add(new HaxeGenericParamModel(part, index));
+        index++;
+      }
+    }
+    return out;
   }
 }
 

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolver.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolver.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +18,60 @@
  */
 package com.intellij.plugins.haxe.model.type;
 
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedHashMap;
 
 public class HaxeGenericResolver {
-  final public Map<String, ResultHolder> resolvers;
+  // This must remain ordered, thus the LinkedHashMap.
+  final private LinkedHashMap<String, ResultHolder> resolvers;
 
   public HaxeGenericResolver() {
-    this.resolvers = new HashMap<String, ResultHolder>();
+    this.resolvers = new LinkedHashMap<String, ResultHolder>();
+  }
+
+  public ResultHolder add(@NotNull String name, @NotNull ResultHolder specificType) {
+    resolvers.put(name, specificType);
+    return specificType;
   }
 
   @Nullable
   public ResultHolder resolve(String name) {
     return resolvers.get(name);
+  }
+
+  /**
+   * @return The names of all generics in this resolver in order of their adding.
+   */
+  @NotNull
+  public String[] names() {
+    String[] names = new String[resolvers.size()];
+    int i = 0;
+    for (String name : resolvers.keySet()) {
+      names[i++] = name;
+    }
+    return names;
+  }
+
+  /**
+   * @return All specific generic types in this resolver in the order of their adding.
+   */
+  @NotNull
+  public ResultHolder[] getSpecifics() {
+    if (resolvers.isEmpty()) return ResultHolder.EMPTY;
+    ResultHolder results[] = new ResultHolder[resolvers.size()];
+    int i = 0;
+    for (ResultHolder result : resolvers.values()) {
+      results[i++] = result;
+    }
+    return results;
+  }
+
+  /**
+   * @return whether or not this resolver has any entries.
+   */
+  public boolean isEmpty() {
+    return resolvers.isEmpty();
   }
 }

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
@@ -206,7 +206,7 @@ public abstract class SpecificTypeReference {
   }
 
   @Nullable
-  public ResultHolder access(String name, HaxeExpressionEvaluatorContext context) {
+  public ResultHolder access(String name, HaxeExpressionEvaluatorContext context, HaxeGenericResolver resolver) {
     return null;
   }
 


### PR DESCRIPTION
- Resolve typedefs to underlying types. (e.g. `var v:Null<String>` is resolved as a `String` type.)
- Propagate type parameters (generics) properly through typedefs.
- Resolve types when used with array access (e.g. `map[0].length` no longer marked as errors).
- Infer types of methods without specific typing (e.g. `map.get(0).length` no longer marked as errors).