### PR TITLE
Fix ClassCastException when building parameter lists (hints) for cons…

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeFunctionDescriptionBuilder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2017-2017 Ilya Malanin
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,9 +44,10 @@ class HaxeFunctionDescriptionBuilder {
   @Nullable
   static HaxeFunctionDescription buildForConstructor(final HaxeNewExpression expression) {
     final HaxeGenericSpecialization specialization = expression.getSpecialization();
-    final HaxeClass haxeClass = (HaxeClass)expression.getType().getReferenceExpression().resolve();
+    final PsiElement resolved = (HaxeClass)expression.getType().getReferenceExpression().resolve();
 
-    if (haxeClass != null) {
+    if (resolved instanceof HaxeClass) {
+      final HaxeClass haxeClass = (HaxeClass)resolved;
       final PsiMethod[] constructors = haxeClass.getConstructors();
       if (constructors.length > 0) {
         final HaxeClassResolveResult resolveResult = HaxeClassResolveResult.create(haxeClass, specialization);


### PR DESCRIPTION
This fixes an exception that occurs when building parameter list hints (Ctrl+P) and a resolved name is not a class element.