### PR TITLE
Extract Variables 2 - Fixes #844, Replaces PR#902

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -82,6 +82,7 @@
       <p/>
       <p>Unreleased Changes:</p>
       <ul>
+        <li>Check type of type check statements (e.g. `(myExpression : Float)`) and warn.  Add quick fixes.</li>
         <li>Auto-close regions and conditionally (un)compiled code, and add checkboxes to the Settings panel for folding.</li>
         <li>Fix Extract Variable and Extract Constant refactorings (Issue #844):
           <ul>
@@ -89,6 +90,7 @@
             <li>Avoid keywords when making name suggestions.</li>
             <li>Fix multi-select for custom names in all occurrences.</li>
             <li>Fix semi-colon insertion/detection.</li>
+            <li>Suggest variable names based upon expression type.</li>
           </ul>
         </li>
         <li>Allow AIR targets to be debugged using the flash system. (Issue #849)</li>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -74,7 +74,7 @@
   <depends optional="true" config-file="flex-debugger-support.xml">com.intellij.flex</depends>
   <depends optional="true" config-file="debugger-support.xml">com.intellij.modules.ultimate</depends>
 
-  <version>1.1@plugin.dev.version@ for @plugin.compatibility.description@</version>
+  <version>POST.1.1.develop.@plugin.dev.version@ for @plugin.compatibility.description@</version>
   <change-notes>
   <![CDATA[
       <p>This jar is compatible with @plugin.compatibility.description@</p>
@@ -83,6 +83,14 @@
       <p>Unreleased Changes:</p>
       <ul>
         <li>Auto-close regions and conditionally (un)compiled code, and add checkboxes to the Settings panel for folding.</li>
+        <li>Fix Extract Variable and Extract Constant refactorings (Issue #844):
+          <ul>
+            <li>Fixed infinite loop when extracting multiple occurrences.</li>
+            <li>Avoid keywords when making name suggestions.</li>
+            <li>Fix multi-select for custom names in all occurrences.</li>
+            <li>Fix semi-colon insertion/detection.</li>
+          </ul>
+        </li>
         <li>Allow AIR targets to be debugged using the flash system. (Issue #849)</li>
       </ul>
       <p>1.1 (HaxeFoundation release)</p>

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/HaxeRefactoringUtil.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/HaxeRefactoringUtil.java
@@ -2,7 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
- * Copyright 2018 Eric Bishton
+ * Copyright 2018-2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,10 @@ public class HaxeRefactoringUtil {
   }
 
   public static Set<String> collectKeywords() {
-    return new THashSet<String>(ContainerUtil.map(HaxeTokenTypeSets.KEYWORDS.getTypes(), (IElementType k)->k.toString()));
+    THashSet<String> words = new THashSet<>(ContainerUtil.map(HaxeTokenTypeSets.KEYWORDS.getTypes(), (IElementType k)->k.toString()));
+    words.addAll(ContainerUtil.map(HaxeTokenTypeSets.PSEUDO_KEYWORDS.getTypes(), (IElementType k)->k.toString()));
+    words.addAll(ContainerUtil.map(HaxeTokenTypeSets.KEYWORD_CONSTANTS.getTypes(), (IElementType k)->k.toString()));
+    return words;
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/HaxeRefactoringUtil.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/HaxeRefactoringUtil.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +21,13 @@ package com.intellij.plugins.haxe.ide.refactoring;
 import com.intellij.codeInsight.PsiEquivalenceUtil;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypeSets;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.lang.psi.impl.ComponentNameScopeProcessor;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.ResolveState;
+import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.Function;
 import com.intellij.util.containers.ContainerUtil;
@@ -51,6 +54,10 @@ public class HaxeRefactoringUtil {
         return componentName.getName();
       }
     }));
+  }
+
+  public static Set<String> collectKeywords() {
+    return new THashSet<String>(ContainerUtil.map(HaxeTokenTypeSets.KEYWORDS.getTypes(), (IElementType k)->k.toString()));
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceOperation.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceOperation.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,14 +34,15 @@ import java.util.List;
  */
 public class HaxeIntroduceOperation {
   private final Project myProject;
-  private final Editor myEditor;
-  private final PsiFile myFile;
+  private Editor myEditor;
+  private PsiFile myFile;
   private String myName;
   private Boolean myReplaceAll;
   private PsiElement myElement;
   private HaxeExpression myInitializer;
   private List<PsiElement> myOccurrences = Collections.emptyList();
   private Collection<String> mySuggestedNames;
+  private boolean nameWasAutoSelectedFromSuggestions;
 
   public HaxeIntroduceOperation(Project project,
                                 Editor editor,
@@ -60,6 +62,19 @@ public class HaxeIntroduceOperation {
     myName = name;
   }
 
+  public void autoSelectName() {
+    assert null == myName : "Name has already been assigned.";
+
+    if (null != mySuggestedNames && !mySuggestedNames.isEmpty()) {
+      nameWasAutoSelectedFromSuggestions = true;
+      setName(mySuggestedNames.iterator().next());
+    }
+  }
+
+  public boolean isNameAutoSelected() {
+    return nameWasAutoSelectedFromSuggestions;
+  }
+
   public Project getProject() {
     return myProject;
   }
@@ -68,8 +83,29 @@ public class HaxeIntroduceOperation {
     return myEditor;
   }
 
+  /**
+   * Updates the current editor when the operation changes the editor that the operation is occurring in, such as when
+   * an embedded element (e.g. regular expression) is moved (e.g. the operation wraps the REGEX_FILE) and the new
+   * element is not in the embedded editor where the operation started.
+   */
+  public Editor updateEditor(Editor editor) {
+    return myEditor = editor;
+  }
+
   public PsiFile getFile() {
     return myFile;
+  }
+
+  /**
+   * Updates the current file when the operation changes the jfile that the operation is occurring in, such as when
+   * an embedded element (e.g. regular expression) is moved (e.g. the operation wraps the REGEX_FILE) and the new
+   * element is not in the embedded file where the operation started.
+   *
+   * @param file
+   * @return
+   */
+  public PsiFile updateFile(PsiFile file) {
+    return myFile = file;
   }
 
   public PsiElement getElement() {

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/introduceField/HaxeIntroduceConstantHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/introduceField/HaxeIntroduceConstantHandler.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +26,7 @@ import com.intellij.plugins.haxe.lang.psi.HaxeClassBody;
 import com.intellij.plugins.haxe.lang.psi.HaxeExpression;
 import com.intellij.plugins.haxe.lang.psi.HaxeFieldDeclaration;
 import com.intellij.plugins.haxe.util.HaxeElementGenerator;
+import com.intellij.plugins.haxe.util.HaxeNameSuggesterUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiRecursiveElementVisitor;
 import com.intellij.psi.PsiWhiteSpace;
@@ -32,6 +34,7 @@ import com.intellij.psi.util.PsiTreeUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -119,5 +122,10 @@ public class HaxeIntroduceConstantHandler extends HaxeIntroduceHandler {
   @Override
   protected HaxeFieldDeclaration createDeclaration(Project project, String text, PsiElement anchor) {
     return HaxeElementGenerator.createVarDeclaration(project, text);
+  }
+
+  @Override
+  protected Collection<String> getSuggestedNames(HaxeExpression expression) {
+    return HaxeNameSuggesterUtil.getSuggestedNames(expression, true);
   }
 }

--- a/src/common/com/intellij/plugins/haxe/lang/lexer/HaxeTokenTypeSets.java
+++ b/src/common/com/intellij/plugins/haxe/lang/lexer/HaxeTokenTypeSets.java
@@ -2,7 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
- * Copyright 2018 Eric Bishton
+ * Copyright 2018-2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,6 +89,17 @@ public interface HaxeTokenTypeSets {
     OPEN_QUOTE,
     CLOSING_QUOTE,
     REGULAR_STRING_PART
+  );
+
+  TokenSet KEYWORD_CONSTANTS = TokenSet.create(
+    KFALSE,
+    KTRUE,
+    KNULL
+  );
+
+  TokenSet PSEUDO_KEYWORDS = TokenSet.create(
+    KTO,
+    KFROM
   );
 
   TokenSet KEYWORDS = TokenSet.create(

--- a/src/common/com/intellij/plugins/haxe/lang/util/HaxeExpressionUtil.java
+++ b/src/common/com/intellij/plugins/haxe/lang/util/HaxeExpressionUtil.java
@@ -1,5 +1,6 @@
 /*
  * Copyright 2018 Ilya Malanin
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,5 +67,10 @@ public class HaxeExpressionUtil {
     final ASTNode token = element.getAssignOperation().getNode().findChildByType(HaxeTokenTypeSets.ASSIGN_OPERATORS);
     if (token != null) return token.getElementType();
     return null;
+  }
+
+  public static boolean isArrayExpression(HaxeExpression expr) {
+    return expr instanceof HaxeArrayLiteral
+           || expr instanceof HaxeArrayAccessExpression;
   }
 }

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
@@ -2,7 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
- * Copyright 2018 Eric Bishton
+ * Copyright 2018-2019 Eric Bishton
  * Copyright 2018 Ilya Malanin
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -139,9 +139,17 @@ public abstract class SpecificTypeReference {
   }
 
   final public boolean isArray() {
+    return isNamedType(ARRAY);
+  }
+
+  final public boolean isMap() {
+    return isNamedType(MAP);
+  }
+
+  private boolean isNamedType(String typeName) {
     if (this instanceof SpecificHaxeClassReference) {
       final SpecificHaxeClassReference reference = (SpecificHaxeClassReference)this;
-      return reference.getHaxeClassReference().getName().equals(ARRAY);
+      return reference.getHaxeClassReference().getName().equals(typeName);
     }
     return false;
   }

--- a/src/common/com/intellij/plugins/haxe/util/HaxeElementGenerator.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeElementGenerator.java
@@ -3,6 +3,7 @@
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2017 Ilya Malanin
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +120,14 @@ public class HaxeElementGenerator {
   public static HaxeImportStatement createImportStatementFromPath(Project myProject, String path) {
     final PsiFile dummyFile = createDummyFile(myProject, "import " + path + ";");
     return PsiTreeUtil.getChildOfType(dummyFile, HaxeImportStatement.class);
+  }
+
+  @Nullable
+  public static HaxePsiToken createEmptyStatement(Project myProject) {
+    final HaxeImportStatement importStatement = createImportStatementFromPath(myProject, "Std");
+    PsiElement last = importStatement.getLastChild();
+    assert last instanceof HaxePsiToken;
+    return last instanceof HaxePsiToken ? (HaxePsiToken)last : null;
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/util/HaxeNameSuggesterUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeNameSuggesterUtil.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +19,14 @@
 package com.intellij.plugins.haxe.util;
 
 import com.intellij.openapi.util.text.StringUtil;
+import com.intellij.plugins.haxe.ide.refactoring.HaxeRefactoringUtil;
+import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.lang.util.HaxeExpressionUtil;
+import com.intellij.plugins.haxe.model.type.*;
+import com.intellij.psi.codeStyle.NameUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashSet;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -41,34 +44,225 @@ public class HaxeNameSuggesterUtil {
   }
 
   @NotNull
-  public static Collection<String> generateNames(@NotNull String name) {
+  public static String prepareNameTextForSuggestions(@NotNull String name) {
+    // Note: decapitalize only changes the first letter to lower case, but won't do if the second letter is also uppercase.
     name = StringUtil.decapitalize(deleteNonLetterFromString(StringUtil.unquoteString(name.replace('.', '_'))));
-    if (name.startsWith("get")) {
-      name = name.substring(3);
+
+    //if (name.startsWith("get") && name.length() > 3) {
+    //  name = name.substring(3);
+    //}
+    //else if (name.startsWith("is") && name.length() > 2) {
+    //  name = name.substring(2);
+    //}
+    //while (name.startsWith("_") && name.length() > 1) {
+    //  name = name.substring(1);
+    //}
+    //while (name.endsWith("_") && name.length() > 1) {
+    //  name = name.substring(0, name.length() - 1);
+    //}
+    //return name;
+
+    StringBuilder prepped = new StringBuilder();
+    int startPos = 0;
+    int endPos = name.length() - 1;
+
+    // Trim (skip past) underscores and common leading words.
+    // (Leave an underscore or name if that is the entirety of the remaining text.)
+    while (startPos < endPos && '_' == name.charAt(startPos)) ++startPos;
+    while (endPos > startPos && '_' == name.charAt(endPos)) --endPos;
+    for (String prefix : new String[]{"get", "is"}) {
+      if (name.startsWith(prefix) && (endPos - startPos) > prefix.length()) {
+        startPos += prefix.length();
+      }
     }
-    else if (name.startsWith("is")) {
-      name = name.substring(2);
+
+    // Copy the string, removing consecutive underscores.
+    char c = '_';  // Assume last char is '_' to skip any underscores after 'get' or 'is', as in get_myVar();
+    for (int i = startPos; i <= endPos; i++) {
+      if (c == '_' && name.charAt(i) == '_') continue;
+      c = name.charAt(i);
+      prepped.append(c);
     }
-    while (name.startsWith("_")) {
-      name = name.substring(1);
+
+    return prepped.toString();
+  }
+
+
+  @NotNull
+  public static Collection<String> generateNames(@NotNull String name, boolean useUpperCase, boolean isArray) {
+    name = prepareNameTextForSuggestions(name);
+
+    Collection<String> candidates = new LinkedHashSet<String>();
+    if (null != name && !name.isEmpty()) {
+      candidates.addAll(NameUtil.getSuggestionsByName(name, "", "", useUpperCase, false, isArray));
     }
-    while (name.endsWith("_")) {
-      name = name.substring(0, name.length() - 1);
+    return candidates;
+  }
+
+  @NotNull
+  public static String getDefaultExpressionName(HaxeExpression expression, boolean useUpperCase) {
+    String lower = getDefaultExpressionName(expression);
+    return useUpperCase ? lower.toUpperCase() : lower;
+  }
+
+  @NotNull
+  public static String getDefaultExpressionName(HaxeExpression expression) {
+    ResultHolder typeResult = HaxeTypeResolver.getPsiElementType(expression, new HaxeGenericResolver());
+    SpecificTypeReference type = typeResult.getType();
+
+    if (type.isDynamic()) { return "dyn"; }
+    if (type.isVoid()) { return "v"; }
+    if (type.isInt()) { return "i"; }
+    if (type.isBool()) { return "b"; }
+    if (type.isFloat()) { return "f"; }
+    if (type.isString()) { return "str"; }
+    if (type.isArray()) { return "arr"; }
+    if (type.isMap()) { return "map"; }
+
+    if (type instanceof SpecificHaxeClassReference) {
+      SpecificHaxeClassReference ref = (SpecificHaxeClassReference)type;
+      HaxeClass clazz = ref.getHaxeClass();
+      String name = null == clazz ? null : clazz.getName();
+      if (null != name) {
+        return HaxeStringUtil.toLowerFirst(name);
+      }
     }
-    final int length = name.length();
-    final Collection<String> possibleNames = new LinkedHashSet<String>();
-    for (int i = 0; i < length; i++) {
-      if (Character.isLetter(name.charAt(i)) &&
-          (i == 0 || name.charAt(i - 1) == '_' || (Character.isLowerCase(name.charAt(i - 1)) && Character.isUpperCase(name.charAt(i))))) {
-        final String candidate = StringUtil.decapitalize(name.substring(i));
-        if (candidate.length() < 25) {
-          possibleNames.add(candidate);
+
+    // If result typing doesn't work (e.g. it's Unknown or Invalid), then try against
+    // the kind of expression.
+
+    if (expression instanceof HaxeAssignExpression
+        || expression instanceof HaxeReferenceExpression) {
+      return "var"; // Should come out of expression.getType() or a resolve(),
+    }
+    if (expression instanceof HaxePrefixExpression) {  // Wraps statements, like HaxeIfStatement
+      return "expr";
+    }
+    if (expression instanceof HaxeSwitchCaseExpression) {
+      return "switchResult";
+    }
+    if (expression instanceof HaxeBitwiseExpression
+        || expression instanceof HaxeShiftExpression) {
+      return "bitResult";
+    }
+    if (expression instanceof HaxeLogicAndExpression
+        || expression instanceof HaxeLogicOrExpression
+        || expression instanceof HaxeCompareExpression) {
+      return "logicalResult";
+    }
+    if (expression instanceof HaxeSuperExpression) {
+      return "mysuper";
+    }
+    if (expression instanceof HaxeFatArrowExpression
+        || expression instanceof HaxeFunctionLiteral) {
+      return "lambda";
+    }
+    if (expression instanceof HaxeStringLiteralExpression) {
+      return "str";
+    }
+    if (expression instanceof HaxeCallExpression) {
+      return "functionResult";
+    }
+    if (expression instanceof HaxeThisExpression) {
+      return "myself";
+    }
+    if (expression instanceof HaxeTernaryExpression) {
+      return "ternaryResult";
+    }
+    if (expression instanceof HaxeIteratorExpression) {
+      return "iter";
+    }
+    if (expression instanceof HaxeAdditiveExpression
+        || expression instanceof HaxeMultiplicativeExpression) {
+      return "f"; // float
+    }
+    if (expression instanceof HaxeMapLiteral) {
+      return "map";
+    }
+    if (expression instanceof HaxeArrayLiteral) {
+      return "arr";
+    }
+    if (expression instanceof HaxeArrayAccessExpression) {
+      return "element";
+    }
+    if (expression instanceof HaxeRegularExpression
+        || expression instanceof HaxeRegularExpressionLiteral) {  // These must come before HaxeLiteralExpression
+      return "regex";
+    }
+    if (expression instanceof HaxeLiteralExpression    // Must come after RegularExpressionXXX
+        || expression instanceof HaxeConstantExpression) {
+      return "const";
+    }
+    if (expression instanceof HaxeNewExpression) {
+      return "newObj";
+    }
+    if (expression instanceof HaxeCastExpression) {
+      return "cast";
+    }
+    if (expression instanceof HaxeObjectLiteral) {
+      return "anon";  // Anonymous structure.  Maybe should be comprised of element names??
+    }
+    if (expression instanceof HaxeParenthesizedExpression) {
+      return "result";  // Should be typed!
+    }
+    if (expression instanceof HaxePropertyAccessor) {
+      return "prop";
+    }
+    if (expression instanceof HaxeTypeCheckExpr) {
+      HaxeTypeCheckExpr expr = (HaxeTypeCheckExpr) expression;
+      HaxeFunctionType functionType = expr.getFunctionType();
+      if (null != functionType) {
+        return functionType.getName();
+      } else {
+        HaxeTypeOrAnonymous toa = expr.getTypeOrAnonymous();
+        if (null != toa) {
+          HaxeType haxeType = toa.getType();
+          if (null == haxeType && null != toa.getAnonymousType()) {
+            return "anon";
+          }
+          if (null != haxeType) {
+            String name = haxeType.getName();
+            if (null != name) {
+              return name;
+            }
+          }
         }
       }
     }
-    // prefer shorter names
-    ArrayList<String> reversed = new ArrayList<String>(possibleNames);
-    Collections.reverse(reversed);
-    return reversed;
+
+    return "x";
+  }
+
+  @NotNull
+  public static Collection<String> getSuggestedNames(final HaxeExpression expression, final boolean wantUpperCase) {
+    String text = expression.getText();
+    boolean useUpperCase = wantUpperCase;
+    boolean isArray = HaxeExpressionUtil.isArrayExpression(expression);
+    if (expression instanceof HaxeCallExpression) {
+      final HaxeExpression callee = ((HaxeCallExpression)expression).getExpression();
+      text = callee.getText();
+    } else if (expression instanceof HaxeRegularExpression) {
+      text = "REGEX_";
+      useUpperCase = true;
+    }
+
+    Collection<String> candidates = text == null ? new LinkedHashSet<String>()
+                                                 : HaxeNameSuggesterUtil.generateNames(text, useUpperCase, isArray);
+    candidates.add(HaxeNameSuggesterUtil.getDefaultExpressionName(expression, useUpperCase));
+
+    final Set<String> usedNames = HaxeRefactoringUtil.collectUsedNames(expression);
+    usedNames.addAll(HaxeRefactoringUtil.collectKeywords());
+    final Collection<String> result = new ArrayList<String>();
+
+    for (String candidate : candidates) {
+      int index = 0;
+      String suffix = "";
+      while (usedNames.contains(candidate + suffix)) {
+        suffix = Integer.toString(++index);
+      }
+      result.add(candidate + suffix);
+    }
+
+    return result;
   }
 }

--- a/src/common/com/intellij/plugins/haxe/util/HaxeStringUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeStringUtil.java
@@ -2,7 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
- * Copyright 2017-2018 Eric Bishton
+ * Copyright 2017-2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -228,4 +228,21 @@ public class HaxeStringUtil {
     return s.substring(0, len - ELLIPSES.length()) + ELLIPSES;
   }
 
+
+  /**
+   * Gets a version of the given string with a lower-cased first character.
+   * @param s - string to change.
+   */
+  @Nullable
+  public static String toLowerFirst(@Nullable String s) {
+    if (null == s) return null;
+    if (s.isEmpty()) return s;
+    if (!Character.isUpperCase(s.charAt(0))) return s;
+    char lower = Character.toLowerCase(s.charAt(0));
+    StringBuilder builder = new StringBuilder(lower);
+    if (s.length() > 1) {
+      builder.append(s.substring(1));
+    }
+    return builder.toString();
+  }
 }

--- a/testData/refactoring/introduceVariable/ExtractAnonymousFunction.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractAnonymousFunction.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var this1 = function(ab:Int) {return this;};
+        var anonymous = this1;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractAnonymousFunction.hx
+++ b/testData/refactoring/introduceVariable/ExtractAnonymousFunction.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var anonymous = <selection>function(ab:Int) {return this;}</selection>;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractAnonymousStructure.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractAnonymousStructure.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var y = {x:1, y:1};
+        var k = y;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractAnonymousStructure.hx
+++ b/testData/refactoring/introduceVariable/ExtractAnonymousStructure.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var k = {x:1, <selection>y</selection>:1};
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractArrayComprehension.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractArrayComprehension.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var js = [for (j in 0...10) return j;];
+        var myArr = js;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractArrayComprehension.hx
+++ b/testData/refactoring/introduceVariable/ExtractArrayComprehension.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var myArr = [for (j in 0...10) re<selection>t</selection>urn j;];
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractArrayLiteral.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractArrayLiteral.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var arr = [0, 1, 2, 3];
+        for (i in arr) Sys.println(i);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractArrayLiteral.hx
+++ b/testData/refactoring/introduceVariable/ExtractArrayLiteral.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        for (i in <selection>[0,1,2,3]</selection>) Sys.println(i);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractArrowFunctionWithCurlyBrackets.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractArrowFunctionWithCurlyBrackets.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var this1 = () -> {return this;};
+        var getThis = this1;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractArrowFunctionWithCurlyBrackets.hx
+++ b/testData/refactoring/introduceVariable/ExtractArrowFunctionWithCurlyBrackets.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var getThis = <selection>() -> {return this;}</selection>
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractCall.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractCall.after.hx
@@ -1,0 +1,13 @@
+package ;
+class Test {
+    var pi = Std.string(3.1416);
+
+    function doSomething(k : String, v : String) {
+        trace("I like " + k);
+        trace("I mean " + pi);
+    }
+    static function main() {
+        var test = new Test();
+        test.doSomething("Blueberry", pi);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractCall.hx
+++ b/testData/refactoring/introduceVariable/ExtractCall.hx
@@ -1,0 +1,11 @@
+package ;
+class Test {
+    function doSomething(k : String, v : String) {
+        trace("I like " + k);
+        trace("I mean " + Std.string(3.1416));
+    }
+    static function main() {
+        var test = new Test();
+        test.doSomething("Blueberry", <selection>Std.string(3.1416)</selection>);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractFloat.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractFloat.after.hx
@@ -3,7 +3,7 @@ class Test {
     function new() {
         // Default name is x (when everything else fails), but we don't want a duplicate.
         var x = false;
-        var x1 = 1.0 + 2.0;
-        var y = x1 + Std.int("3.0");
+        var f = 1.0 + 2.0;
+        var y = f + Std.int("3.0");
     }
 }

--- a/testData/refactoring/introduceVariable/ExtractFloat.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractFloat.after.hx
@@ -1,0 +1,9 @@
+package;
+class Test {
+    function new() {
+        // Default name is x (when everything else fails), but we don't want a duplicate.
+        var x = false;
+        var x1 = 1.0 + 2.0;
+        var y = x1 + Std.int("3.0");
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractFloat.hx
+++ b/testData/refactoring/introduceVariable/ExtractFloat.hx
@@ -1,0 +1,8 @@
+package;
+class Test {
+    function new() {
+        // Default name is x (when everything else fails), but we don't want a duplicate.
+        var x = false;
+        var y = <selection>1.0 + 2.0</selection> + Std.int("3.0");
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractMapLiteral.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractMapLiteral.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var map = ["1" => 1, "2" => 2];
+        for (i in map.keys()) Sys.println(i);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractMapLiteral.hx
+++ b/testData/refactoring/introduceVariable/ExtractMapLiteral.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        for (i in [<selection>"1" => 1, "2" => 2</selection>].keys()) Sys.println(i);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractMapLiteralWithFunction.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractMapLiteralWithFunction.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var keys = ["1" => 1, "2" => 2].keys();
+        for (i in keys) Sys.println(i);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractMapLiteralWithFunction.hx
+++ b/testData/refactoring/introduceVariable/ExtractMapLiteralWithFunction.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        for (i in ["1" => 1, "2" => 2].<selection>keys()</selection>) Sys.println(i);
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractNamedFunction.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractNamedFunction.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var this1 = function named(ab:Int) {return this;};
+        var named = this1;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractNamedFunction.hx
+++ b/testData/refactoring/introduceVariable/ExtractNamedFunction.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var named = <selection>function</selection> named(ab:Int) {return this;};
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractRegex.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractRegex.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var REGEX = ~/Hello/i;
+        var myregex = REGEX;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractRegex.hx
+++ b/testData/refactoring/introduceVariable/ExtractRegex.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var myregex = ~/He<selection>l</selection>lo/i;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractRegex2.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractRegex2.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var REGEX = ~/string/i;
+        if (REGEX.match("MyString")) trace("yes");
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractRegex2.hx
+++ b/testData/refactoring/introduceVariable/ExtractRegex2.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        if (~/str<selection>i</selection>ng/i.match("MyString")) trace("yes");
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractSimpleArrowFunction.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractSimpleArrowFunction.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var this1 = () -> return this;
+        var another = this1;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractSimpleArrowFunction.hx
+++ b/testData/refactoring/introduceVariable/ExtractSimpleArrowFunction.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var another = <selection>() -> return this</selection>;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractString.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractString.after.hx
@@ -1,0 +1,7 @@
+package ;
+class Test {
+    function new() {
+        var kommisar = "Der Kommisar";
+        var whoami = kommisar;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractString.hx
+++ b/testData/refactoring/introduceVariable/ExtractString.hx
@@ -1,0 +1,6 @@
+package ;
+class Test {
+    function new() {
+        var whoami = <selection>"Der Kommisar"</selection>;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractThis.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractThis.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var this1 = this;
+        var myinstance = this1;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractThis.hx
+++ b/testData/refactoring/introduceVariable/ExtractThis.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var myinstance = <selection>this</selection>;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractVariableDeclaration.after.hx
+++ b/testData/refactoring/introduceVariable/ExtractVariableDeclaration.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+    function new() {
+        var n1 = var n = 1;
+        var m = n1;
+    }
+}

--- a/testData/refactoring/introduceVariable/ExtractVariableDeclaration.hx
+++ b/testData/refactoring/introduceVariable/ExtractVariableDeclaration.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    function new() {
+        var m = <selection>var n</selection> = 1;
+    }
+}

--- a/testData/refactoring/introduceVariable/ReplaceConstant.after.hx
+++ b/testData/refactoring/introduceVariable/ReplaceConstant.after.hx
@@ -1,7 +1,7 @@
 package;
 class Test {
   function new() {
-      var TRUE = true;
-      var myVal = TRUE;
+      var true1 = true;
+      var myVal = true1;
   }
 }

--- a/testData/refactoring/introduceVariable/ReplaceConstant.after.hx
+++ b/testData/refactoring/introduceVariable/ReplaceConstant.after.hx
@@ -1,0 +1,7 @@
+package;
+class Test {
+  function new() {
+      var TRUE = true;
+      var myVal = TRUE;
+  }
+}

--- a/testData/refactoring/introduceVariable/ReplaceConstant.hx
+++ b/testData/refactoring/introduceVariable/ReplaceConstant.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+  function new() {
+    var myVal = <selection>true</selection>;
+  }
+}

--- a/testData/refactoring/introduceVariable/ReplaceConstantAll.after.hx
+++ b/testData/refactoring/introduceVariable/ReplaceConstantAll.after.hx
@@ -1,14 +1,14 @@
 package;
 class Test {
-    var TRUE = true;
+    var true1 = true;
 
     function new() {
-        var myVal = TRUE;
-        var val2 = TRUE;
-        var val3 = TRUE;
+        var myVal = true1;
+        var val2 = true1;
+        var val3 = true1;
     }
 
     function another() {
-        var tryme = TRUE;
+        var tryme = true1;
     }
 }

--- a/testData/refactoring/introduceVariable/ReplaceConstantAll.after.hx
+++ b/testData/refactoring/introduceVariable/ReplaceConstantAll.after.hx
@@ -1,0 +1,14 @@
+package;
+class Test {
+    var TRUE = true;
+
+    function new() {
+        var myVal = TRUE;
+        var val2 = TRUE;
+        var val3 = TRUE;
+    }
+
+    function another() {
+        var tryme = TRUE;
+    }
+}

--- a/testData/refactoring/introduceVariable/ReplaceConstantAll.hx
+++ b/testData/refactoring/introduceVariable/ReplaceConstantAll.hx
@@ -1,0 +1,12 @@
+package;
+class Test {
+    function new() {
+        var myVal = true;
+        var val2 = <selection>true</selection>;
+        var val3 = true;
+    }
+
+    function another() {
+        var tryme = true;
+    }
+}

--- a/testData/refactoring/introduceVariable/ReplaceThis.after.hx
+++ b/testData/refactoring/introduceVariable/ReplaceThis.after.hx
@@ -1,0 +1,9 @@
+package;
+class Test {
+  var instance : Test;
+
+  function new() {
+    var myThis = this;
+    var instance = myThis;
+  }
+}

--- a/testData/refactoring/introduceVariable/ReplaceThis.hx
+++ b/testData/refactoring/introduceVariable/ReplaceThis.hx
@@ -1,0 +1,8 @@
+package;
+class Test {
+  var instance : Test;
+
+  function new() {
+    var instance = <selection>this</selection>;
+  }
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceTestBase.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceTestBase.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,15 +59,19 @@ public abstract class HaxeIntroduceTestBase extends HaxeCodeInsightFixtureTestCa
   }
 
   protected void doTest(@Nullable Consumer<HaxeIntroduceOperation> customization, boolean replaceAll) {
+    doTest(customization, replaceAll, "foo", false);
+  }
+
+  protected void doTest(@Nullable Consumer<HaxeIntroduceOperation> customization, boolean replaceAll, String newname, boolean inPlace) {
     String testName = getTestName(true);
     testName = convertStringFirstLetterToUppercase(testName);
     myFixture.configureByFile(testName + ".hx");
     boolean inplaceEnabled = myFixture.getEditor().getSettings().isVariableInplaceRenameEnabled();
     try {
-      myFixture.getEditor().getSettings().setVariableInplaceRenameEnabled(false);
+      myFixture.getEditor().getSettings().setVariableInplaceRenameEnabled(inPlace);
       HaxeIntroduceHandler handler = createHandler();
       final HaxeIntroduceOperation operation =
-        new HaxeIntroduceOperation(myFixture.getProject(), myFixture.getEditor(), myFixture.getFile(), "foo");
+        new HaxeIntroduceOperation(myFixture.getProject(), myFixture.getEditor(), myFixture.getFile(), newname);
       operation.setReplaceAll(replaceAll);
       if (customization != null) {
         customization.consume(operation);
@@ -85,26 +90,10 @@ public abstract class HaxeIntroduceTestBase extends HaxeCodeInsightFixtureTestCa
   }
 
   protected void doTestInplace(@Nullable Consumer<HaxeIntroduceOperation> customization) {
-    String name = getTestName(true);
-    name = convertStringFirstLetterToUppercase(name);
-    myFixture.configureByFile(name + ".hx");
-    final boolean enabled = myFixture.getEditor().getSettings().isVariableInplaceRenameEnabled();
-    TemplateManagerImpl.setTemplateTesting(getProject(), getTestRootDisposable());
-    myFixture.getEditor().getSettings().setVariableInplaceRenameEnabled(true);
+    doTestInplace(customization, true, "a");
+  }
 
-    HaxeIntroduceHandler handler = createHandler();
-    final HaxeIntroduceOperation introduceOperation =
-      new HaxeIntroduceOperation(myFixture.getProject(), myFixture.getEditor(), myFixture.getFile(), "a");
-    introduceOperation.setReplaceAll(true);
-    if (customization != null) {
-      customization.consume(introduceOperation);
-    }
-    handler.performAction(introduceOperation);
-
-    TemplateState state = TemplateManagerImpl.getTemplateState(myFixture.getEditor());
-    assert state != null;
-    state.gotoEnd(false);
-    myFixture.checkResultByFile(name + ".after.hx", true);
-    myFixture.getEditor().getSettings().setVariableInplaceRenameEnabled(enabled);
+  protected void doTestInplace(@Nullable Consumer<HaxeIntroduceOperation> customization, boolean replaceAll, String newname) {
+    doTest(customization, replaceAll, newname, true);
   }
 }

--- a/testSrc/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceVariableTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceVariableTest.java
@@ -109,4 +109,32 @@ public class HaxeIntroduceVariableTest extends HaxeIntroduceTestBase {
   public void testExtractFloat() throws Throwable {
     doTestInplace(null, true, null);
   }
+
+  public void testExtractAnonymousStructure() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractVariableDeclaration() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractMapLiteral() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractMapLiteralWithFunction() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractArrayLiteral() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractArrayComprehension() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractRegex2() throws Throwable {
+    doTestInplace(null, true, null);
+  }
 }

--- a/testSrc/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceVariableTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/refactoring/introduce/HaxeIntroduceVariableTest.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2018 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,5 +64,49 @@ public class HaxeIntroduceVariableTest extends HaxeIntroduceTestBase {
 
   public void testSuggestName2() throws Throwable {
     doTestSuggestions(HaxeCallExpression.class, "test1");
+  }
+
+  public void testReplaceConstant() throws Throwable {
+    doTestInplace(null, false, null);
+  }
+
+  public void testReplaceConstantAll() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractRegex() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractThis() throws Throwable {
+    doTestInplace(null, false, null);
+  }
+
+  public void testExtractString() throws Throwable {
+    doTestInplace(null, false, null);
+  }
+
+  public void testExtractCall() throws Throwable {
+    doTestInplace(null, true, "pi");
+  }
+
+  public void testExtractAnonymousFunction() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractNamedFunction() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractArrowFunctionWithCurlyBrackets() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractSimpleArrowFunction() throws Throwable {
+    doTestInplace(null, true, null);
+  }
+
+  public void testExtractFloat() throws Throwable {
+    doTestInplace(null, true, null);
   }
 }


### PR DESCRIPTION
Fix Extract Variable and Extract Constant refactorings (Issue #844):
- Fixed infinite loop when extracting multiple occurrences.
- Avoid keywords when making name suggestions.
- Fix multi-select for custom names in all occurrences.
- Fix semi-colon insertion/detection.
