### PR TITLE
Abstract type checking

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -84,6 +84,7 @@
       <ul>
         <li>Fixed constructor being renamed when a class is renamed (refactored).  (Issue #776, #785)</li>
         <li>Fixed ClassCastException when Refactor->Rename was used on generic type names.</li>
+        <li>No longer display type mismatch errors when using abstracts with (varying) generic type parameters.  (e.g. Null<String>, Null<Test>)</li>
         <li>Better detection of types inferred after declaration (monomorphs).</li>
         <li>Fixed type detection for expressions in parenthesis.</li>
         <li>Detect simple type mismatches in declarations and assignments.  Add quick fixes for them.</li>

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -155,13 +155,15 @@ class TypeTagChecker {
   }
 
   @NotNull
-  private static ResultHolder getTypeFromVarInit(HaxeVarInit init) {
+  private static ResultHolder getTypeFromVarInit(@NotNull HaxeVarInit init) {
     final ResultHolder abstractEnumFieldInitType = HaxeAbstractEnumUtil.getStaticMemberExpression(init.getExpression());
     if (abstractEnumFieldInitType != null) {
       return abstractEnumFieldInitType;
     }
     // fallback to simple init expression
-    return HaxeTypeResolver.getPsiElementType(init.getExpression(), init, HaxeGenericResolverUtil.generateResolverFromScopeParents(init));
+    HaxeExpression initExpression = init.getExpression();
+    return null != initExpression ? HaxeTypeResolver.getPsiElementType(initExpression, init, HaxeGenericResolverUtil.generateResolverFromScopeParents(init))
+                                  : SpecificTypeReference.getInvalid(init).createHolder();
   }
 }
 

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -3,7 +3,7 @@
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2018 Ilya Malanin
- * Copyright 2018 Eric Bishton
+ * Copyright 2018-2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -388,6 +388,12 @@ public class HaxeClassModel implements HaxeExposableModel {
         classType.getHaxeClassModel().writeCompatibleTypes(output);
       }
     }
+
+    // TODO: Add types from @:from and @:to methods, including inferred method types.
+  }
+
+  public boolean hasGenericParams() {
+    return getPsi().getGenericParam() != null;
   }
 
   public List<HaxeGenericParamModel> getGenericParams() {

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
@@ -345,12 +345,12 @@ public class HaxeTypeResolver {
   }
 
   @NotNull
-  static public ResultHolder getPsiElementType(PsiElement element, HaxeGenericResolver resolver) {
+  static public ResultHolder getPsiElementType(@NotNull PsiElement element, HaxeGenericResolver resolver) {
     return getPsiElementType(element, (PsiElement)null, resolver);
   }
 
   @NotNull
-  static public ResultHolder getPsiElementType(PsiElement element, @Nullable PsiElement resolveContext, HaxeGenericResolver resolver) {
+  static public ResultHolder getPsiElementType(@NotNull PsiElement element, @Nullable PsiElement resolveContext, HaxeGenericResolver resolver) {
     if (element == resolveContext) return SpecificTypeReference.getInvalid(element).createHolder();
     if (element instanceof HaxeReferenceExpression) {
       PsiElement targetElement = ((HaxeReferenceExpression)element).resolve();
@@ -397,7 +397,7 @@ public class HaxeTypeResolver {
   }
 
   @NotNull
-  static public HaxeExpressionEvaluatorContext getPsiElementType(PsiElement element, @Nullable AnnotationHolder holder,
+  static public HaxeExpressionEvaluatorContext getPsiElementType(@NotNull PsiElement element, @Nullable AnnotationHolder holder,
                                                                  HaxeGenericResolver resolver) {
     return evaluateFunction(new HaxeExpressionEvaluatorContext(element, holder), resolver);
   }

--- a/testData/annotation.semantic/NoErrorOnMultipleNullT.hx
+++ b/testData/annotation.semantic/NoErrorOnMultipleNullT.hx
@@ -1,0 +1,9 @@
+package;
+class Test{
+  var x:Null<String> = null;
+  var y:Null<Test> = null;
+  function new() {
+    x = "New String";
+    y = this; // <-- Should not have error: "Incompatible types; Test should be Null<Test>."
+  }
+}

--- a/testData/annotation.semantic/std/StdTypes.hx
+++ b/testData/annotation.semantic/std/StdTypes.hx
@@ -1,12 +1,12 @@
-extern enum Void { }
-extern class Float { }
-extern class Int extends Float { }
-typedef Null<T> = T
-extern enum Bool {
-  true;
-  false;
+@:coreType abstract Void { }
+@:coreType @:notNull @:runtimeValue abstract Float { }
+@:coreType @:notNull @:runtimeValue abstract Int to Float { }
+@:forward @:coreType abstract Null<T> from T to T { }
+@:coreType @:notNull @:runtimeValue @:enum abstract Bool {
+  false = 0;
+  true = !false;
 }
-extern class Dynamic<T> { }
+abstract Dynamic<T> { }
 typedef Iterator<T> = {
   function hasNext() : Bool;
   function next() : T;
@@ -14,4 +14,7 @@ typedef Iterator<T> = {
 typedef Iterable<T> = {
   function iterator() : Iterator<T>;
 }
-extern interface ArrayAccess<T> { }
+typedef KeyValueIterator<K,V> = Iterator<{key:K, value:V}>;
+typedef KeyValueIterable<K,V> = {
+    function keyValueIterator():KeyValueIterator<K,V>;
+}extern interface ArrayAccess<T> { }

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -3,7 +3,7 @@
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2018 Ilya Malanin
- * Copyright 2018 Eric Bishton
+ * Copyright 2018-2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     final HaxeTypeAnnotator annotator = new HaxeTypeAnnotator();
     LanguageAnnotators.INSTANCE.addExplicitExtension(HaxeLanguage.INSTANCE, annotator);
     myFixture.enableInspections(getAnnotatorBasedInspection());
-    myFixture.testHighlighting(true, false, true);
+    myFixture.testHighlighting(checkWarnings, checkInfos, checkWeakWarnings);
   }
 
   private void doTestNoFixWithWarnings(String... additionalFiles) throws Exception {
@@ -398,4 +398,7 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings("std/StdTypes.hx");
   }
 
+  public void testNoErrorOnMultipleNullT() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx");
+  }
 }


### PR DESCRIPTION
No longer display type mismatch errors when using abstracts with (varying) generic type parameters.  (e.g. `Null<String>, Null<Test>`)