### PR TITLE
Ready plugin.xml for post 1.2 development.

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -74,12 +74,15 @@
   <depends optional="true" config-file="flex-debugger-support.xml">com.intellij.flex</depends>
   <depends optional="true" config-file="debugger-support.xml">com.intellij.modules.ultimate</depends>
 
-  <version>1.2@plugin.dev.version@ for @plugin.compatibility.description@</version>
+  <version>POST.1.2.develop@plugin.dev.version@ for @plugin.compatibility.description@</version>
   <change-notes>
   <![CDATA[
       <p>This jar is compatible with @plugin.compatibility.description@</p>
       <p>It was built using IDEA build @idea.sdk.version@</p>
       <p/>
+      <p>Unreleased Changes</p>
+      <ul>
+      </ul>
       <p>1.2 (HaxeFoundation release)</p>
       <ul>
         <li>Update builds for 2019.1 and 2018.x versions.</li>


### PR DESCRIPTION
Just updates the plugin.xml so that products built from the develop branch aren't marked as the 1.2 release.