### PR TITLE
Fix map typing error

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -74,12 +74,15 @@
   <depends optional="true" config-file="flex-debugger-support.xml">com.intellij.flex</depends>
   <depends optional="true" config-file="debugger-support.xml">com.intellij.modules.ultimate</depends>
 
-  <version>1.2@plugin.dev.version@ for @plugin.compatibility.description@</version>
+  <version>POST.1.2.develop@plugin.dev.version@ for @plugin.compatibility.description@</version>
   <change-notes>
   <![CDATA[
       <p>This jar is compatible with @plugin.compatibility.description@</p>
       <p>It was built using IDEA build @idea.sdk.version@</p>
       <p/>
+      <p>Unreleased Changes</p>
+      <ul>
+      </ul>
       <p>1.2 (HaxeFoundation release)</p>
       <ul>
         <li>Update builds for 2019.1 and 2018.x versions.</li>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -82,6 +82,7 @@
       <p/>
       <p>Unreleased Changes</p>
       <ul>
+        <li>Use type parameters from left-hand (e.g. left.right) expressions when resolving right-hand fields and method return types.</li>
       </ul>
       <p>1.2 (HaxeFoundation release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -156,13 +156,16 @@ class TypeTagChecker {
 
   @NotNull
   private static ResultHolder getTypeFromVarInit(@NotNull HaxeVarInit init) {
-    final ResultHolder abstractEnumFieldInitType = HaxeAbstractEnumUtil.getStaticMemberExpression(init.getExpression());
+    HaxeExpression initExpression = init.getExpression();
+    HaxeGenericResolver resolver = HaxeGenericResolverUtil.generateResolverFromScopeParents(initExpression);
+
+    final ResultHolder abstractEnumFieldInitType = HaxeAbstractEnumUtil.getStaticMemberExpression(initExpression, resolver);
     if (abstractEnumFieldInitType != null) {
       return abstractEnumFieldInitType;
     }
+
     // fallback to simple init expression
-    HaxeExpression initExpression = init.getExpression();
-    return null != initExpression ? HaxeTypeResolver.getPsiElementType(initExpression, init, HaxeGenericResolverUtil.generateResolverFromScopeParents(init))
+    return null != initExpression ? HaxeTypeResolver.getPsiElementType(initExpression, init, resolver)
                                   : SpecificTypeReference.getInvalid(init).createHolder();
   }
 }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeClassResolveResult.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeClassResolveResult.java
@@ -249,6 +249,11 @@ public class HaxeClassResolveResult implements Cloneable {
     return specialization;
   }
 
+  @NotNull
+  public HaxeGenericResolver getGenericResolver() {
+    return specialization.toGenericResolver(haxeClass);
+  }
+
   public void specialize(@Nullable PsiElement element) {
     if (element == null || haxeClass == null || !haxeClass.isGeneric()) {
       return;

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -145,7 +145,7 @@ public class HaxeClassModel implements HaxeExposableModel {
     List<HaxeType> types = new LinkedList<HaxeType>();
     for (HaxeIdentifier id : UsefulPsiTreeUtil.getChildren(haxeClass, HaxeIdentifier.class)) {
       if (id.getText().equals("to")) {
-        PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingNoSpaces(id);
+        PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingSkipWhiteSpacesAndComments(id);
         if (sibling instanceof HaxeType) {
           types.add((HaxeType)sibling);
         }
@@ -160,7 +160,7 @@ public class HaxeClassModel implements HaxeExposableModel {
     List<HaxeType> types = new LinkedList<HaxeType>();
     for (HaxeIdentifier id : UsefulPsiTreeUtil.getChildren(haxeClass, HaxeIdentifier.class)) {
       if (id.getText().equals("from")) {
-        PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingNoSpaces(id);
+        PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingSkipWhiteSpacesAndComments(id);
         if (sibling instanceof HaxeType) {
           types.add((HaxeType)sibling);
         }

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
@@ -199,7 +199,8 @@ public class HaxeExpressionEvaluator {
           }
         }
       }
-      return SpecificHaxeClassReference.withGenerics(new HaxeClassReference(model, element), resolver.getSpecifics()).createHolder();
+      ResultHolder[] specifics =  HaxeTypeResolver.resolveParametersToTypes(model.haxeClass, resolver);
+      return SpecificHaxeClassReference.withGenerics(new HaxeClassReference(model, element), specifics).createHolder();
     }
 
     if (element instanceof HaxeIdentifier) {
@@ -372,7 +373,7 @@ public class HaxeExpressionEvaluator {
         if (reference != null) {
           PsiElement subelement = reference.resolve();
           if (subelement instanceof AbstractHaxeNamedComponent) {
-            typeHolder = HaxeTypeResolver.getFieldOrMethodReturnType((AbstractHaxeNamedComponent)subelement);
+            typeHolder = HaxeTypeResolver.getFieldOrMethodReturnType((AbstractHaxeNamedComponent)subelement, resolver);
           }
         }
       }

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolver.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolver.java
@@ -18,6 +18,7 @@
  */
 package com.intellij.plugins.haxe.model.type;
 
+import com.intellij.plugins.haxe.lang.psi.HaxeClass;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -74,6 +75,17 @@ public class HaxeGenericResolver {
       results[i++] = result;
     }
     return results;
+  }
+
+  @NotNull
+  public ResultHolder[] getSpecificsFor(@Nullable HaxeClassReference clazz) {
+    return getSpecificsFor(clazz != null ? clazz.getHaxeClass() : null);
+  }
+
+  @NotNull
+  public ResultHolder[] getSpecificsFor(@Nullable HaxeClass hc) {
+    if (null == hc) return ResultHolder.EMPTY;
+    return HaxeTypeResolver.resolveParametersToTypes(hc, this);
   }
 
   /**

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolverUtil.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolverUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Eric Bishton
+ * Copyright 2018-2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,10 @@
  */
 package com.intellij.plugins.haxe.model.type;
 
-import com.intellij.plugins.haxe.lang.psi.HaxeClass;
-import com.intellij.plugins.haxe.lang.psi.HaxeMethod;
+import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.model.HaxeClassModel;
 import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +31,7 @@ public class HaxeGenericResolverUtil {
     HaxeGenericResolver resolver = new HaxeGenericResolver();
     appendClassGenericResolver(element, resolver);
     appendMethodGenericResolver(element, resolver);
-
+    appendStatementGenericResolver(HaxeResolveUtil.getLeftReference(element), resolver);
     return resolver;
   }
 
@@ -57,6 +57,20 @@ public class HaxeGenericResolverUtil {
       resolver.addAll(model.getGenericResolver(resolver));
     }
 
+    return resolver;
+  }
+
+  @Nullable static HaxeGenericResolver appendStatementGenericResolver(PsiElement element, @NotNull HaxeGenericResolver resolver) {
+    if (null == element) return resolver;
+
+    HaxeReference left = HaxeResolveUtil.getLeftReference(element);
+    if ( null != left) {
+      appendStatementGenericResolver(left, resolver);
+    }
+    if (element instanceof HaxeReference) {
+      HaxeClassResolveResult result = ((HaxeReference)element).resolveHaxeClass();
+      resolver.addAll(result.getGenericResolver());
+    }
     return resolver;
   }
 

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
@@ -3,7 +3,7 @@
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2018 Ilya Malanin
- * Copyright 2018 Eric Bishton
+ * Copyright 2018-2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ public class HaxeTypeResolver {
   static private ResultHolder getFieldType(AbstractHaxeNamedComponent comp, HaxeGenericResolver resolver) {
     //ResultHolder type = getTypeFromTypeTag(comp);
     // Here detect assignment
-    final ResultHolder abstractEnumType = HaxeAbstractEnumUtil.getFieldType(comp);
+    final ResultHolder abstractEnumType = HaxeAbstractEnumUtil.getFieldType(comp, resolver);
     if (abstractEnumType != null) {
       return abstractEnumType;
     }

--- a/testData/annotation.semantic/EitherTypeTest.hx
+++ b/testData/annotation.semantic/EitherTypeTest.hx
@@ -1,0 +1,28 @@
+// This abstract came from  https://github.com/HaxeFoundation/hxnodejs/blob/3bb5b4d97455318f09cc0f5491e284293b2504c9/src/js/node/Cluster.hx#L107
+
+package ;
+class AbstractEnumEitherTypeTest {
+    public function new() {
+        var leat : Float = ListeningEventAddressType.UDPv4;  // No error because int can be assigned to float.
+        var leatInt : Int = ListeningEventAddressType.TCPv4; // No error.
+        var leatString : String = ListeningEventAddressType.UDPv4; // No error.
+
+        var <error descr="Incompatible type: ListeningEventAddressType should be Bool">leatBool : Bool = ListeningEventAddressType.Unix</error>; // Should be an error.
+    }
+}
+/**
+	Structure emitted by 'listening' event.
+**/
+typedef ListeningEventAddress = {
+    var address:String;
+    var port:Int;
+    var addressType:ListeningEventAddressType;
+}
+
+@:enum abstract ListeningEventAddressType(/*haxe.extern.*/EitherType<Int,String>) to /*haxe.extern.*/EitherType<Int,String> {
+    var TCPv4 = 4;
+    var TCPv6 = 6;
+    var Unix = -1;
+    var UDPv4 = "udp4";
+    var UDPv6 = "udp6";
+}

--- a/testData/annotation.semantic/NoIncompatibleTypeErrorOnChainedMaps.hx
+++ b/testData/annotation.semantic/NoIncompatibleTypeErrorOnChainedMaps.hx
@@ -1,0 +1,17 @@
+// File should not have any errors.
+package;
+
+class Test {
+  private var myMap : Map<Int, Map<String,String>>;
+
+
+  public function new() {
+    myMap = [1 => [ "something" => "somevalue",
+              "else" => "elsevalue"
+                ]
+            ];
+  }
+  public function test() {
+    var val : String = myMap.get(1).get("something");
+  }
+}

--- a/testData/annotation.semantic/NoIncompatibleTypeErrorOnMap.hx
+++ b/testData/annotation.semantic/NoIncompatibleTypeErrorOnMap.hx
@@ -1,0 +1,15 @@
+// File should not have any errors.
+package;
+
+class Test {
+  private var myMap : Map<String, String>;
+
+  public function new() {
+    myMap = [ "something" => "somevalue",
+              "else" => "elsevalue"
+            ];
+  }
+  public function test() {
+    var val : String = myMap.get("something");  // Original issue was: Null<Unknown> should be String.
+  }
+}

--- a/testData/annotation.semantic/std/EitherType.hx
+++ b/testData/annotation.semantic/std/EitherType.hx
@@ -1,0 +1,3 @@
+// package haxe.extern;
+package;
+abstract EitherType<T1,T2>(Dynamic) from T1 to T1 from T2 to T2 {}

--- a/testData/annotation.semantic/std/Map.hx
+++ b/testData/annotation.semantic/std/Map.hx
@@ -1,0 +1,37 @@
+/* Elided/edited version of Map from Haxe Toolkit 3.4.7 */
+
+@:multiType(@:followWithAbstracts K)
+abstract Map<K,V>(IMap<K,V> ) {
+	public function new();
+	public inline function set(key:K, value:V) this.set(key, value);
+	@:arrayAccess public inline function get(key:K) return this.get(key);
+	public inline function exists(key:K) return this.exists(key);
+	public inline function remove(key:K) return this.remove(key);
+	public inline function keys():Iterator<K> { Return this.keys();	}
+	public inline function iterator():Iterator<V> { return this.iterator();	}
+	public inline function toString():String { return this.toString(); }
+	@:arrayAccess @:noCompletion public inline function arrayWrite(k:K, v:V):V {
+		this.set(k, v);
+		return v;
+	}
+
+}
+
+@:dox(hide)
+@:deprecated
+typedef IMap<K, V> = constrainedIMap<K, V>;
+
+
+interface constrainedIMap<K,V> {
+	public function get(k:K):Null<V>;
+	public function set(k:K, v:V):Void;
+	public function exists(k:K):Bool;
+	public function remove(k:K):Bool;
+	public function keys():Iterator<K>;
+	public function iterator():Iterator<V>;
+	public function toString():String;
+}
+
+
+
+

--- a/testData/annotation.semantic/std/String.hx
+++ b/testData/annotation.semantic/std/String.hx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C)2005-2017 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+/*
+  Comments elided.  From the 3.4.7 SDK.
+**/
+extern class String {
+	var length(default,null) : Int;
+	function new(string:String) : Void;
+	function toUpperCase() : String;
+	function toLowerCase() : String;
+	function charAt(index : Int) : String;
+	function charCodeAt( index : Int) : Null<Int>;
+	function indexOf( str : String, ?startIndex : Int ) : Int;
+	function lastIndexOf( str : String, ?startIndex : Int ) : Int;
+	function split( delimiter : String ) : Array<String>;
+	function substr( pos : Int, ?len : Int ) : String;
+	function substring( startIndex : Int, ?endIndex : Int ) : String;
+	function toString() : String;
+	@:pure static function fromCharCode( code : Int ) : String;
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -400,4 +400,16 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
   public void testNoErrorOnMultipleNullT() throws Exception {
     doTestNoFixWithWarnings("std/StdTypes.hx");
   }
+
+  public void testNoIncompatibleTypeErrorOnMap() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Map.hx", "std/String.hx");
+  }
+
+  public void testNoIncompatibleTypeErrorOnChainedMaps() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Map.hx", "std/String.hx");
+  }
+
+  public void testEitherTypeTest() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/String.hx", "std/EitherType.hx");
+  }
 }


### PR DESCRIPTION
This propagates type parameters from the left-hand side of an expression (e.g. left.right) to the right-hand side during resolution.  Doing so fixes type resolution for Maps and other abstract types based upon a parameterized type.