### PR TITLE
Build on IDEA 2019.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,33 @@ env:
   - IDEA_VERSION=2016.3.8
   - IDEA_VERSION=2017.3.5
   - IDEA_VERSION=2018.2.8
-  - IDEA_VERSION=2019.1.1
+  - IDEA_VERSION=2019.1.3
+  - IDEA_VERSION=2019.2
 os:
   - linux
   - osx
 
-osx_image: xcode9.3
+# Null (blank) options allow us to create a larger matrix, from which we can exclude invalid options.
+osx_image: 
+  - xcode9.3
+  - 
+jdk: 
+  - openjdk8
+  -
+
+# Excluding allows us to remove specific sets from the matrix.  In this case, it is imperative
+# that we do NOT include any jdk: for osx.  The secondary goal of removing xcode from linux
+# builds is mostly cosmetic.
+matrix:
+  exclude:
+  - os: osx
+    jdk: openjdk8
+  - os: osx
+    osx_image:
+  - os: linux
+    jdk:
+  - os: linux
+    osx_image: xcode9.3
 
 before_script: |
   #Linux

--- a/build.gradle
+++ b/build.gradle
@@ -69,11 +69,6 @@ allprojects {
         psiTargetFile = "light-psi-all.jar"
     }
 
-    File propertiesFile = file("${ideaTargetDir}/build.txt")
-    Properties buildProperties = propertiesFile.exists()
-                                    ? findSdkValuesAndProperties(propertiesFile)
-                                    : new Properties()
-
     apply plugin: 'idea'
     apply plugin: 'org.jetbrains.intellij'
     apply from: "${haxePluginDir}/template.gradle"
@@ -88,9 +83,10 @@ allprojects {
         // Don't let gradle fill in since/until, we fill them via patchCustomTags using the properties file.
         updateSinceUntilBuild false
         // Include the "java" built-in plugin for 2019.2 and later builds.
-        String codeline = buildProperties.getProperty('idea.sdk.codeline')
-        if (null != codeline && codeline.toInteger() >= 192) {
-            plugins 'java' // 2019.2 + only.  Causes build errors on earlier versions.
+        String[] versionInfo = "${ideaVersion}".split("\\.")
+        if (versionInfo.size() >= 2 && (versionInfo[0].toInteger() > 2019 || (versionInfo[0].toInteger() == 2019 && versionInfo[1].toInteger() >= 2))) {
+            System.println("Including java plugin for version >= 2019.2")
+            plugins 'java'  // 2019.2 + only.  Causes build errors on earlier versions.
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,10 @@ allprojects {
         psiTargetFile = "light-psi-all.jar"
     }
 
-    Properties buildProperties = findSdkValuesAndProperties(file("${ideaTargetDir}/build.txt"))
+    File propertiesFile = file("${ideaTargetDir}/build.txt")
+    Properties buildProperties = propertiesFile.exists()
+                                    ? findSdkValuesAndProperties(propertiesFile)
+                                    : new Properties()
 
     apply plugin: 'idea'
     apply plugin: 'org.jetbrains.intellij'
@@ -85,7 +88,8 @@ allprojects {
         // Don't let gradle fill in since/until, we fill them via patchCustomTags using the properties file.
         updateSinceUntilBuild false
         // Include the "java" built-in plugin for 2019.2 and later builds.
-        if (buildProperties.getProperty('idea.sdk.codeline').toInteger() >= 192) {
+        String codeline = buildProperties.getProperty('idea.sdk.codeline')
+        if (null != codeline && codeline.toInteger() >= 192) {
             plugins 'java' // 2019.2 + only.  Causes build errors on earlier versions.
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@
 
 plugins {
     id 'de.undercouch.download' version '3.3.0'
-    id 'org.jetbrains.intellij' version '0.3.12'
+    id 'org.jetbrains.intellij' version '0.4.9'
 }
 
 
@@ -69,6 +69,8 @@ allprojects {
         psiTargetFile = "light-psi-all.jar"
     }
 
+    Properties buildProperties = findSdkValuesAndProperties(file("${ideaTargetDir}/build.txt"))
+
     apply plugin: 'idea'
     apply plugin: 'org.jetbrains.intellij'
     apply from: "${haxePluginDir}/template.gradle"
@@ -78,8 +80,14 @@ allprojects {
         version = "IU-${ideaVersion}"
         pluginName = "intellij-haxe-${ideaVersion}"
         ideaDependencyCachePath "${ideaBaseDir}"
+        // Specify the sandbox so that Gradle doesn't try to make it relative to each sub-project.
+        sandboxDirectory "${project.rootDir}/build/idea-sandbox"
         // Don't let gradle fill in since/until, we fill them via patchCustomTags using the properties file.
         updateSinceUntilBuild false
+        // Include the "java" built-in plugin for 2019.2 and later builds.
+        if (buildProperties.getProperty('idea.sdk.codeline').toInteger() >= 192) {
+            plugins 'java' // 2019.2 + only.  Causes build errors on earlier versions.
+        }
     }
 }
 
@@ -139,7 +147,7 @@ dependencies {
 }
 
 runIde {
-    jbreVersion 'jbrex8u152b1248.6'
+    jbrVersion '8u202b1483.37'
 }
 
 compileJava {

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,9 +22,9 @@ org.gradle.daemon.idletimeout=1
 # Avoid out of memmory on compile
 org.gradle.jvmargs=-Xms512m -Xmx512m
 
-defaultIdeaVersion=2019.2.1
+defaultIdeaVersion=2019.2
 
-latest2019Version=2019.2.1
+latest2019Version=2019.2
 latest2018Version=2018.3.6
 latest2017Version=2017.3.5
 latest2016Version=2016.3.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,9 +22,9 @@ org.gradle.daemon.idletimeout=1
 # Avoid out of memmory on compile
 org.gradle.jvmargs=-Xms512m -Xmx512m
 
-defaultIdeaVersion=2019.1.1
+defaultIdeaVersion=2019.2.1
 
-latest2019Version=2019.1.1
+latest2019Version=2019.2.1
 latest2018Version=2018.3.6
 latest2017Version=2017.3.5
 latest2016Version=2016.3.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -71,6 +71,7 @@
   <vendor>Haxe Community (Original sources provided by JetBrains.)</vendor>
   <idea-version since-build="@plugin.installable.since@" until-build="@plugin.installable.until@"/>
   <depends>com.intellij.modules.lang</depends>
+  <depends>com.intellij.modules.java</depends>
   <depends optional="true" config-file="flex-debugger-support.xml">com.intellij.flex</depends>
   <depends optional="true" config-file="debugger-support.xml">com.intellij.modules.ultimate</depends>
 


### PR DESCRIPTION
A couple of tweaks to get the plugin to build on 2019.2.  We needed to declare our requirement of the built-in "java" plugin as described here: https://blog.jetbrains.com/platform/2019/06/java-functionality-extracted-as-a-plugin/

