### PR TITLE
Better type checking

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -83,6 +83,14 @@
       <p/>
       <p>Unreleased Changes</p>
       <ul>
+        <li>Better constant detection and handling of default parameters for methods.</li>
+        <ul>
+          <li>Detect initialization calculations containing only constants as constant.</li>
+          <li>Detect several standard library functions as returning constants when their arguments are constant. (e.g. Std.int("1"))</li>
+          <li>Detect identifiers/constants referencing other constants as still constant.</li>
+          <li>Detect enums without parameters as constants.</li>
+          <li>Better flagging of errors when default parameters <i>are not</i> constants.</li>
+        </ul>
         <li>Much better handling of generics throughout, including type error checking code.</li>
         <li>Use type parameters from left-hand (e.g. left.right) expressions when resolving right-hand fields and method return types.</li>
       </ul>

--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeGenericSpecialization.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeGenericSpecialization.java
@@ -28,6 +28,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author: Fedor.Korotkov
@@ -190,6 +191,19 @@ public class HaxeGenericSpecialization implements Cloneable {
     }
     result.append(genericName);
     return result.toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    HaxeGenericSpecialization that = (HaxeGenericSpecialization)o;
+    return map.equals(that.map);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(map);
   }
 
   public String debugDump() {

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -531,6 +531,11 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
       }
     }
 
+    if (isType(resolve, HaxeEnumValueDeclaration.class)) {
+      final HaxeEnumDeclaration enumDeclaration = UsefulPsiTreeUtil.getParentOfType(resolve, HaxeEnumDeclaration.class);
+      return HaxeClassResolveResult.create(enumDeclaration, getSpecialization());
+    }
+
     if (isType(resolve, HaxeClass.class)) {
       // Classes (particularly typedefs) that are already resolved should not be
       // re-resolved to their component parts.

--- a/src/common/com/intellij/plugins/haxe/lang/util/HaxeExpressionUtil.java
+++ b/src/common/com/intellij/plugins/haxe/lang/util/HaxeExpressionUtil.java
@@ -161,6 +161,9 @@ public class HaxeExpressionUtil {
     ||  is_type(expr, HaxeConstantExpression.class)) {
       PsiElement childElement = expr.getFirstChild();
       IElementType type = null != childElement ? childElement.getNode().getElementType() : null;
+      if (null == type) {  // Optimize failure case.
+        return ConstantClass.NOT_CONSTANT;
+      }
       if (type == HaxeTokenTypes.KTRUE
           ||  type == HaxeTokenTypes.KFALSE) {
         return ConstantClass.BOOLEAN;

--- a/src/common/com/intellij/plugins/haxe/lang/util/HaxeExpressionUtil.java
+++ b/src/common/com/intellij/plugins/haxe/lang/util/HaxeExpressionUtil.java
@@ -20,14 +20,27 @@ import com.intellij.lang.ASTNode;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypeSets;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.model.HaxeFieldModel;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
 import com.intellij.psi.tree.IElementType;
 import com.intellij.psi.util.PsiTreeUtil;
+import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class HaxeExpressionUtil {
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getLogger();
+  static {LOG.setLevel(Level.DEBUG);}  // Remove when done debugging.
+
+  private static final ThreadLocal<ArrayList<PsiElement>> constantsInProcess =
+    new ThreadLocal<>().withInitial(()->new ArrayList<>());
+
   @Nullable
   public static IElementType getOperationType(@NotNull HaxeExpression expression) {
     final ASTNode token = expression.getNode().findChildByType(HaxeTokenTypeSets.UNARY_OPERATORS);
@@ -73,4 +86,294 @@ public class HaxeExpressionUtil {
     return expr instanceof HaxeArrayLiteral
            || expr instanceof HaxeArrayAccessExpression;
   }
+
+  /**
+   * Determine if an expression is a constant expression eligible to be used as the
+   * right-hand-side of a "static inline var", such that the compiler will consider
+   * the variable to be a constant usable as the default value in parameter lists.
+   *
+   * NOTE: This is likely going to be an arms race unless we match the algorithm in
+   * the compiler.
+   *
+   * @param expr - the expression to test.
+   * @return true, if the expression is considered constant; false, otherwise.
+   */
+  public static boolean isConstantExpression(HaxeExpression expr) {
+    return ConstantClass.NOT_CONSTANT != classifyConstantExpression(expr);
+  }
+
+  /**
+   * Resolve the the type of the constant, if it *is* a constant.
+   * @return The ConstantClass, or NULL if the element is not constant.
+   */
+  private static ConstantClass classifyConstantExpression(HaxeExpression expr) {
+    // Protect from circular references.
+    if (constantsInProcess.get().contains(expr)) {
+      return ConstantClass.NOT_CONSTANT;
+    }
+    constantsInProcess.get().add(expr);
+    try {
+
+      ConstantClass cc = innerClassifier(expr);
+      return cc;
+
+    } finally {
+      constantsInProcess.get().remove(expr);
+    }
+  }
+
+  private static ConstantClass innerClassifier(HaxeExpression expr) {
+
+    if (null == expr) return ConstantClass.NOT_CONSTANT;
+
+    // According to Simn:
+    // Functions, arrays, maps, and anonymous objects are NOT considered constant
+    // expressions.  The compiler ensures that "inline field == inline field" always
+    // holds.  If arrays were allowed, e.g. "static inline var myconstant = []",
+    // then "myconstant == myconstant" would come out as "[] == []" and that's false.
+
+    // Compiler's check:
+    //
+    //    let type_function_arg_value ctx t c do_display =
+    //        match c with
+    //            | None -> None
+    //            | Some e ->
+    //                let p = pos e in
+    //                let e = if do_display then Display.ExprPreprocessing.process_expr ctx.com e else e in
+    //                let e = ctx.g.do_optimize ctx (type_expr ctx e (WithType.with_type t)) in
+    //                unify ctx e.etype t p;
+    //                let rec loop e = match e.eexpr with
+    //                    | TConst _ -> Some e
+    //                    | TField({eexpr = TTypeExpr _},FEnum _) -> Some e
+    //                    | TCast(e,None) -> loop e
+    //                    | _ ->
+    //                         if ctx.com.display.dms_kind = DMNone || ctx.com.display.dms_inline && ctx.com.display.dms_error_policy = EPCollect then
+    //                             display_error ctx "Parameter default value should be constant" p;
+    //                         None
+    //               in
+    //               loop e
+
+    // Maps, Arrays, Function Literals, Object, Anonymous, Block Statements are
+    // Haxe LiteralExpressions.  Booleans, LITINT, LITHEX, LITOCT, LITFLOAT, true, false, null
+    // are either HaxeLiteralExpressions OR HaxeConstantExpressions, depending upon
+    // the rule that they matched in the BNF.
+    if (is_type(expr, HaxeLiteralExpression.class)
+    ||  is_type(expr, HaxeConstantExpression.class)) {
+      PsiElement childElement = expr.getFirstChild();
+      IElementType type = null != childElement ? childElement.getNode().getElementType() : null;
+      if (type == HaxeTokenTypes.KTRUE
+          ||  type == HaxeTokenTypes.KFALSE) {
+        return ConstantClass.BOOLEAN;
+      }
+      if (type == HaxeTokenTypes.KNULL) {
+        return ConstantClass.NULL;
+      }
+      if (type == HaxeTokenTypes.LITFLOAT
+          ||  type == HaxeTokenTypes.LITINT
+          ||  type == HaxeTokenTypes.LITHEX
+          ||  type == HaxeTokenTypes.LITOCT) {
+        return ConstantClass.NUMERIC;
+      }
+      if (type == HaxeTokenTypes.STRING_LITERAL_EXPRESSION) {
+        return ConstantClass.STRING;
+      }
+      if (type == HaxeTokenTypes.REGULAR_EXPRESSION_LITERAL) {
+        return ConstantClass.REGEX;
+      }
+      return ConstantClass.NOT_CONSTANT;
+    }
+
+    if (is_type(expr, HaxeRegularExpression.class)) { // Is also a HaxeLiteralExpression, so must come first.
+      return ConstantClass.REGEX;
+    }
+
+    if (is_type(expr, HaxeStringLiteralExpression.class)) {
+      // If there are $vars in string, then they are not constants.
+      // It doesn't matter whether $var points to a constant, the string is still not constant.
+      return ((HaxeStringLiteralExpression)expr).getLongTemplateEntryList().isEmpty() &&
+             ((HaxeStringLiteralExpression)expr).getShortTemplateEntryList().isEmpty()
+             ? ConstantClass.STRING
+             : ConstantClass.NOT_CONSTANT;
+    }
+
+    if (is_type(expr, HaxeParenthesizedExpression.class)) {
+      return classifyConstantExpression(((HaxeParenthesizedExpression)expr).getExpression());
+    }
+
+    // Unary expressions.
+    if (is_type(expr, HaxePrefixExpression.class)) {
+      // Only, negation ('-'), not ('!'), and bitwise complement ('~') are allowed.
+      PsiElement child = expr.getFirstChild();
+      IElementType type = null != child ? child.getNode().getElementType() : null;
+      if (HaxeTokenTypes.OMINUS.equals(type) ||
+          HaxeTokenTypes.ONOT.equals(type) ||
+          HaxeTokenTypes.OCOMPLEMENT.equals(type)) {
+        return classifyConstantExpression(((HaxePrefixExpression)expr).getExpression());
+      }
+      return ConstantClass.NOT_CONSTANT;
+    }
+    // Binary expressions.
+    if (is_type(expr, HaxeAdditiveExpression.class)) return areConstant(((HaxeAdditiveExpression)expr).getExpressionList());
+    if (is_type(expr, HaxeBitwiseExpression.class)) return areConstant(((HaxeBitwiseExpression)expr).getExpressionList());
+    if (is_type(expr, HaxeCompareExpression.class)) return areConstant(((HaxeCompareExpression)expr).getExpressionList());
+    if (is_type(expr, HaxeLogicAndExpression.class)) return areConstant(((HaxeLogicAndExpression)expr).getExpressionList());
+    if (is_type(expr, HaxeLogicOrExpression.class)) return areConstant(((HaxeLogicOrExpression)expr).getExpressionList());
+    if (is_type(expr, HaxeMultiplicativeExpression.class)) return areConstant(((HaxeMultiplicativeExpression)expr).getExpressionList());
+    if (is_type(expr, HaxeShiftExpression.class)) return areConstant(((HaxeShiftExpression)expr).getExpressionList());
+
+    // Ternary expression.
+    if (is_type(expr, HaxeTernaryExpression.class)) {
+      // Even Simple ternaries with static inline comparisions fail compilation.
+      // e.g.: static inline var c = 1 > 0 ? true : false;
+      return ConstantClass.NOT_CONSTANT;
+    }
+
+    if (is_type(expr, HaxeCastExpression.class)) {
+      // Casts without a target type are allowed.
+      HaxeCastExpression cast = (HaxeCastExpression)expr;
+      return null == cast.getFunctionType() &&
+             null == cast.getTypeOrAnonymous()
+             ? ConstantClass.NOT_CONSTANT
+             : classifyConstantExpression(cast.getExpression());
+    }
+
+    if (is_type(expr, HaxeReferenceExpression.class)) {
+      HaxeReferenceExpression ref = (HaxeReferenceExpression)expr;
+      PsiElement resolved = ref.resolve();
+      if (resolved instanceof HaxeEnumValueDeclaration) { // sub-class of HaxeFieldDeclaration
+        // Only empty (non-parameterized) enumerations are constant.
+        HaxeParameterList parameterList = ((HaxeEnumValueDeclaration)resolved).getParameterList();
+        List<HaxeParameter> params = null == parameterList ? null : parameterList.getParameterList();
+        return null == params || params.isEmpty()
+               ? ConstantClass.ENUMERATION
+               : ConstantClass.NOT_CONSTANT;
+      }
+      if (resolved instanceof HaxeFieldDeclaration) {
+        HaxeFieldDeclaration fieldDeclaration = (HaxeFieldDeclaration)resolved;
+        HaxeFieldModel fieldModel = new HaxeFieldModel(fieldDeclaration);
+        return classifyConstantExpression(fieldModel.getInitializerExpression());
+      }
+      return resolved instanceof HaxeExpression
+             ? classifyConstantExpression((HaxeExpression)resolved)
+             : ConstantClass.NOT_CONSTANT;
+    }
+
+    if (is_type(expr, HaxeCallExpression.class)) {
+      // Any arguments that are non-constant make the call non-constant.
+      ConstantClass classification = classifyCallExpression((HaxeCallExpression)expr);
+      if (ConstantClass.NOT_CONSTANT != classification) {
+        HaxeExpressionList params = ((HaxeCallExpression)expr).getExpressionList();
+        List<HaxeExpression> expressions = params.getExpressionList();
+        for (HaxeExpression expression : expressions) {
+          if (!isConstantExpression(expression)) {
+            return ConstantClass.NOT_CONSTANT;
+          }
+        }
+      }
+      return classification;
+    }
+
+    LOG.debug("Unexpected expression type being checked for constant-ness:" + expr);
+    return ConstantClass.NOT_CONSTANT;
+  }
+
+  private static ConstantClass areConstant(List<HaxeExpression> exprList) {
+    // Need to check that each is a constant, _and_ that they are of compatible (assignable) types.
+    // Luckily, only numeric values are compatible, so we only have to check that each type is numeric, if the
+    // types are different.
+
+    // The good news is that we don't need a full resolve.  We can just check the expression types.
+
+    if (null == exprList || exprList.isEmpty()) return ConstantClass.NOT_CONSTANT;
+
+    ConstantClass firstType = null;
+    for (HaxeExpression expr : exprList) {
+      ConstantClass type = classifyConstantExpression(expr);
+      if (type == ConstantClass.NOT_CONSTANT) {
+        return ConstantClass.NOT_CONSTANT;
+      }
+      if (null == firstType) {
+        firstType = type;
+      } else {
+        if (!type.isCompatibleWith(firstType)) {
+          return ConstantClass.NOT_CONSTANT;
+        }
+      }
+    }
+    return null == firstType ? ConstantClass.NOT_CONSTANT : firstType;
+  }
+
+  @NotNull
+  private static ConstantClass classifyCallExpression(HaxeCallExpression callExpr) {
+    // According to Simn: Some functions are optimized in the compiler if they
+    // have static arguments: Type.enumIndex, String.fromCharCode,
+    // Std.string, Std.int, Math.ceil, Math.floor, Std.is.
+
+    HaxeExpression expr = callExpr.getExpression();
+    PsiReference ref = expr.getReference();
+    PsiElement resolved = null != ref ? ref.resolve() : null;
+    String methodName = resolved instanceof HaxeMethod ? ((HaxeMethod)resolved).getName() : null;
+
+    PsiElement parentClass = UsefulPsiTreeUtil.getParentOfType(resolved, HaxeClass.class);
+    String className = parentClass instanceof HaxeClass ? ((HaxeClass)parentClass).getName() : null;
+
+    if ("Std".equals(className)) {
+
+      if ("int".equals(methodName)) return ConstantClass.NUMERIC;
+      if ("string".equals(methodName)) return ConstantClass.STRING;
+      if ("is".equals(methodName)) return ConstantClass.BOOLEAN;
+
+    } else if ("Type".equals(className)) {
+
+      if ("enumIndex".equals(methodName)) return ConstantClass.NUMERIC;
+
+    } else if ("String".equals(className)) {
+
+      if ("fromCharCode".equals(methodName)) return ConstantClass.STRING;
+
+    } else if ("Math".equals(className)) {
+
+      if ("ceil".equals(methodName)) return ConstantClass.NUMERIC;
+      if ("floor".equals(methodName)) return ConstantClass.NUMERIC;
+
+    }
+
+    return ConstantClass.NOT_CONSTANT;
+  }
+
+  enum ConstantClass {
+    NOT_CONSTANT,
+    NUMERIC,
+    STRING,
+    REGEX,
+    NULL,
+    BOOLEAN,
+    ENUMERATION;
+
+    public boolean isCompatibleWith(ConstantClass right) {
+      switch (this) {
+        case NOT_CONSTANT:  return false;
+        case NULL:          return false; // Never compatible in combinations.
+        case STRING:
+        case REGEX:
+          switch (right) {
+            case STRING:
+            case REGEX:     return true;
+            default:        return false;
+          }
+        default:
+          return this == right;
+      }
+    }
+  }
+
+  private static <T> boolean is_type(final PsiElement element, final Class<T> clazz) {
+    if (clazz.isInstance(element)) {
+      LOG.debug(()->"Element " + element + " is a " + clazz);
+      return true;
+    }
+    LOG.debug(()->"Element " + element + "is not a " +clazz);
+    return false;
+  }
+
 }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -21,6 +21,7 @@ package com.intellij.plugins.haxe.model;
 
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.model.type.*;
+import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiIdentifier;
@@ -136,6 +137,41 @@ public class HaxeClassModel implements HaxeExposableModel {
 
     // TODO: What about function types?
 
+    return null;
+  }
+
+  @Nullable
+  public SpecificHaxeClassReference getUnderlyingClassReference(HaxeGenericResolver resolver) {
+    if (!isAbstract()) return null;
+
+    PsiElement element = getBasePsi();
+    HaxeTypeOrAnonymous typeOrAnon = getUnderlyingType();
+    if (typeOrAnon != null) {
+      HaxeType type = typeOrAnon.getType();
+      if (type != null) {
+        HaxeClass aClass = HaxeResolveUtil.tryResolveClassByQName(type);
+        if (aClass != null) {
+          ResultHolder[] specifics =  HaxeTypeResolver.resolveDeclarationParametersToTypes(aClass, resolver);
+          return SpecificHaxeClassReference.withGenerics(new HaxeClassReference(aClass.getModel(), element), specifics, element);
+        }
+      } else { // Anonymous type
+        HaxeAnonymousType anon = typeOrAnon.getAnonymousType();
+        if (anon != null) {
+          // Anonymous types don't have parameters of their own, but when they are part of a typedef, they use the parameters from it.
+          return SpecificHaxeClassReference.withGenerics(new HaxeClassReference(anon.getModel(), element), resolver.getSpecifics(), element);
+        }
+      }
+    } else {
+      // No typeOrAnon.  This must be Null<T>?
+      if ("Null".equals(getName())) {
+        List<HaxeGenericParamModel> typeParams = getGenericParams();
+        if (typeParams.size() == 1) {
+          HaxeGenericParamModel param = typeParams.get(0);
+          ResultHolder result = resolver.resolve(param.getName());
+          return result.getClassType();
+        }
+      }
+    }
     return null;
   }
 
@@ -379,7 +415,10 @@ public class HaxeClassModel implements HaxeExposableModel {
       final ResultHolder aTypeRef = HaxeTypeResolver.getTypeFromType(type);
       SpecificHaxeClassReference classType = aTypeRef.getClassType();
       if (classType != null) {
-        classType.getHaxeClassModel().writeCompatibleTypes(output);
+        HaxeClassModel model = classType.getHaxeClassModel();
+        if (model != null) {
+          model.writeCompatibleTypes(output);
+        }
       }
     }
 
@@ -388,7 +427,10 @@ public class HaxeClassModel implements HaxeExposableModel {
       final ResultHolder aTypeRef = HaxeTypeResolver.getTypeFromType(type);
       SpecificHaxeClassReference classType = aTypeRef.getClassType();
       if (classType != null) {
-        classType.getHaxeClassModel().writeCompatibleTypes(output);
+        HaxeClassModel model = classType.getHaxeClassModel();
+        if (model != null) {
+          model.writeCompatibleTypes(output);
+        }
       }
     }
 

--- a/src/common/com/intellij/plugins/haxe/model/HaxeFieldModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeFieldModel.java
@@ -3,6 +3,7 @@
  * Copyright 2014-2015 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2018 Ilya Malanin
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +20,7 @@
 package com.intellij.plugins.haxe.model;
 
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.lang.util.HaxeExpressionUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.util.ObjectUtils;
 import org.jetbrains.annotations.NotNull;
@@ -149,5 +151,37 @@ public class HaxeFieldModel extends HaxeMemberModel {
   @Override
   public HaxeExposableModel getExhibitor() {
     return getDeclaringClass();
+  }
+
+  /**
+   * Tells whether a field is a constant, according to the rules for default parameters.
+   *
+   * @return true, if the field is a constant; false, otherwise.
+   */
+  public boolean isConstant() {
+    if (isEnumValue()) {
+      HaxeEnumValueDeclaration enumValue = (HaxeEnumValueDeclaration)getBasePsi();
+      return null == enumValue.getParameterList();  // Only enums without arguments are considered constants.
+    }
+
+    return isStatic() && isInline() && HaxeExpressionUtil.isConstantExpression(getInitializerExpression());
+  }
+
+  public boolean isEnumValue() {
+    return getBasePsi() instanceof HaxeEnumValueDeclaration;
+  }
+
+  /**
+   * Gets the initializer expression for the field.
+   * @return
+   */
+  @Nullable
+  public HaxeExpression getInitializerExpression() {
+    HaxeVarInit initializer = getInitializerPsi();
+    if (null != initializer) {
+      HaxeExpression expression = initializer.getExpression();
+      return expression;
+    }
+    return null;
   }
 }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMemberModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMemberModel.java
@@ -88,6 +88,10 @@ abstract public class HaxeMemberModel extends HaxeBaseMemberModel {
     return hasModifier(HaxePsiModifier.STATIC);
   }
 
+  public boolean isInline() {
+    return hasModifier(INLINE);
+  }
+
   @NotNull
   public PsiElement getNameOrBasePsi() {
     PsiElement element = getNamePsi();

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -619,7 +619,7 @@ public class HaxeResolveUtil {
       result.specialize(initExpression);
       return result;
     }
-    return getHaxeClassResolveResult(initExpression);
+    return getHaxeClassResolveResult(initExpression, specialization);
   }
 
   @NotNull

--- a/testData/annotation.semantic/ErrorOnOptionalParameterWithNonConstMethod.hx
+++ b/testData/annotation.semantic/ErrorOnOptionalParameterWithNonConstMethod.hx
@@ -1,0 +1,6 @@
+package;
+
+class Test {
+  static inline var myConstant:Float = Std.int("12345".substr(2)) * 1; // Not really a constant.
+  static function doSomething(<error descr="Parameter default type should be constant but was Float">v:Float = myConstant</error>) {}
+}

--- a/testData/annotation.semantic/NoErrorOnEnumConstant.hx
+++ b/testData/annotation.semantic/NoErrorOnEnumConstant.hx
@@ -1,0 +1,15 @@
+package;
+class Test {
+    static inline var enumVar = AnEnum.FIRST;
+    static inline var enumVar2 = enumVar;
+
+    static function useEnum(param:AnEnum = AnEnum.SECOND) {}
+    static function useEnum2(param:AnEnum = enumVar) {}
+    static function useEnum3(param:AnEnum = enumVar2) {}
+}
+
+enum AnEnum {
+    FIRST;
+    SECOND;
+}
+

--- a/testData/annotation.semantic/NoErrorOnOptionalParameterWithDoublyReferencedVar.hx
+++ b/testData/annotation.semantic/NoErrorOnOptionalParameterWithDoublyReferencedVar.hx
@@ -1,0 +1,6 @@
+package;
+class Test {
+    static inline var baseVar = 1;
+    static inline var chasingVar = baseVar;
+    static function chase(param:Int = chasingVar) {}
+}

--- a/testData/annotation.semantic/NoErrorOnOptionalParameterWithIntFieldConstant.hx
+++ b/testData/annotation.semantic/NoErrorOnOptionalParameterWithIntFieldConstant.hx
@@ -1,0 +1,9 @@
+package;
+
+class Test {
+  static inline var myConstant:Int = 4;
+
+  public function someFunction(param:Int = myConstant):Void {
+     // The "param:Int = myConstant" gave an Error "Parameter default type should be constant but was Int"
+  }
+}

--- a/testData/annotation.semantic/NoErrorOnOptionalParameterWithParenthesizedNumericFieldConstant.hx
+++ b/testData/annotation.semantic/NoErrorOnOptionalParameterWithParenthesizedNumericFieldConstant.hx
@@ -1,0 +1,7 @@
+package;
+
+class Test {
+  static inline var myConstant = ((Std.int("2") + 10 / 3) - (2 * 1));
+
+  function test(v:Int = myConstant) {}
+}

--- a/testData/annotation.semantic/NoErrorOnOptionalParameterWithParenthesizedStringFieldConstant.hx
+++ b/testData/annotation.semantic/NoErrorOnOptionalParameterWithParenthesizedStringFieldConstant.hx
@@ -1,0 +1,9 @@
+package;
+
+class Test {
+  static inline var myConstant = "123" + (Std.string("456") + "789");
+
+  public function someFunction(param:String = myConstant):Void {
+    // The "param:String = myConstant" gave an Error "Parameter default type should be constant but was String"
+  }
+}

--- a/testData/annotation.semantic/NoErrorOnOptionalParameterWithSimpleStringFieldConstant.hx
+++ b/testData/annotation.semantic/NoErrorOnOptionalParameterWithSimpleStringFieldConstant.hx
@@ -1,0 +1,9 @@
+package;
+
+class Test {
+  static inline var myConstant = "123" + Std.string("456");
+
+  public function someFunction(param:String = myConstant):Void {
+    // The "param:String = myConstant" gave an Error "Parameter default type should be constant but was String"
+  }
+}

--- a/testData/annotation.semantic/std/Std.hx
+++ b/testData/annotation.semantic/std/Std.hx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C)2005-2019 Haxe Foundation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+ // Comments elided.
+extern class Std {
+	public static function is( v : Dynamic, t : Dynamic ) : Bool;
+	public static function downcast<T:{},S:T>( value : T, c : Class<S> ) : S;
+
+	@:deprecated('Std.instance() is deprecated. Use Std.downcast() instead.')
+	public static function instance<T:{},S:T>( value : T, c : Class<S> ) : S;
+	public static function string( s : Dynamic ) : String;
+	public static function int( x : Float ) : Int;
+	public static function parseInt( x : String ) : Null<Int>;
+	public static function parseFloat( x : String ) : Float;
+	public static function random( x : Int ) : Int;
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -444,4 +444,33 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
   //public void testAssignmentOfParameterizedType() throws Exception {
   //  doTestNoFixWithWarnings();
   //}
+
+  public void testNoErrorOnOptionalParameterWithIntFieldConstant() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Std.hx");
+  }
+
+  public void testNoErrorOnOptionalParameterWithSimpleStringFieldConstant() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Std.hx", "std/String.hx");
+  }
+
+  public void testNoErrorOnOptionalParameterWithParenthesizedStringFieldConstant() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Std.hx", "std/String.hx");
+  }
+
+  public void testNoErrorOnOptionalParameterWithParenthesizedNumericFieldConstant() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Std.hx", "std/String.hx");
+  }
+
+  public void testErrorOnOptionalParameterWithNonConstMethod() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Std.hx", "std/String.hx");
+  }
+
+  public void testNoErrorOnOptionalParameterWithDoublyReferencedVar() throws Exception {
+    doTestNoFixWithWarnings("std/StdTypes.hx", "std/Std.hx");
+  }
+
+  public void testNoErrorOnEnumConstant() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
 }


### PR DESCRIPTION
<html>
        <li>Better constant detection and handling of default parameters for methods.</li>
        <ul>
          <li>Detect initialization calculations containing only constants as constant.</li>
          <li>Detect several standard library functions as returning constants when their arguments are constant. (e.g. Std.int("1"))</li>
          <li>Detect identifiers/constants referencing other constants as still constant.</li>
          <li>Detect enums without parameters as constants.</li>
          <li>Better flagging of errors when default parameters <i>are not</i> constants.</li>
</html>