### PR TITLE
Highlight unparseable code regions.

### DIFF
--- a/resources/colorSchemes/HaxeDefault.xml
+++ b/resources/colorSchemes/HaxeDefault.xml
@@ -3,6 +3,7 @@
   ~ Copyright 2000-2013 JetBrains s.r.o.
   ~ Copyright 2014-2014 AS3Boyan
   ~ Copyright 2014-2014 Elias Ku
+  ~ Copyright 2019 Eric Bishton
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -31,6 +32,12 @@
   <option name="HAXE_UNDEFINED_VAR">
     <value>
       <option name="FOREGROUND" value="38492E"/>
+    </value>
+  </option>
+  <option name="HAXE_UNPARSEABLE_DATA">
+    <value>
+      <option name="FOREGROUND" value="38492E"/>
+      <option name="BACKGROUND" value="DADADA"/>
     </value>
   </option>
 </list>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -96,6 +96,7 @@
         </ul>
         <li>Much better handling of generics throughout, including type error checking code.</li>
         <li>Use type parameters from left-hand (e.g. left.right) expressions when resolving right-hand fields and method return types.</li>
+        <li>Color unparseable data when typing; shows developers where functionality is limited while code is invalid.</li>
       </ul>
       <p>1.2 (HaxeFoundation release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -2,7 +2,7 @@
 # Copyright 2000-2013 JetBrains s.r.o.
 # Copyright 2014-2014 AS3Boyan
 # Copyright 2014-2014 Elias Ku
-# Copyright 2017-2018 Eric Bishton
+# Copyright 2017-2019 Eric Bishton
 # Copyright 2017-2018 Ilya Malanin
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -119,6 +119,7 @@ haxe.conditional.compilation.defined.macros=Defined Haxe conditional compilation
 haxe.conditional.compilation.title=Define Haxe Macros
 haxe.conditional.compilation.macros=Conditional compilation macros\:
 haxe.color.settings.description.conditional.compilation=Conditionally non-compiled
+haxe.color.settings.description.unparseable.data=Unparseable data
 haxe.conditional.compilation.setting=Project Macros\:
 haxe.settings.edit=Edit
 haxe.intention.undefine=Undefine flag ''{0}''

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeColorAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeColorAnnotator.java
@@ -3,6 +3,7 @@
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
  * Copyright 2017-2017 Ilya Malanin
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +23,7 @@ import com.intellij.lang.ASTNode;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.Annotator;
+import com.intellij.lang.parser.GeneratedParserUtilBase;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
@@ -91,6 +93,9 @@ public class HaxeColorAnnotator implements Annotator {
       }
       if (tt == HaxeTokenTypeSets.PPBODY) {
         holder.createInfoAnnotation(node, null).setTextAttributes(HaxeSyntaxHighlighterColors.CONDITIONALLY_NOT_COMPILED);
+      }
+      if (tt == GeneratedParserUtilBase.DUMMY_BLOCK) {
+        holder.createInfoAnnotation(node, "Unparseable data").setTextAttributes(HaxeSyntaxHighlighterColors.UNPARSEABLE_DATA);
       }
     }
   }

--- a/src/common/com/intellij/plugins/haxe/ide/highlight/HaxeColorSettingsPage.java
+++ b/src/common/com/intellij/plugins/haxe/ide/highlight/HaxeColorSettingsPage.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +34,8 @@ import java.util.Map;
 import static com.intellij.plugins.haxe.ide.highlight.HaxeSyntaxHighlighterColors.*;
 
 /**
+ * Color Settings page for Haxe: Settings->Editor->Color Scheme->Haxe
+ *
  * @author fedor.korotkov
  */
 public class HaxeColorSettingsPage implements ColorSettingsPage {
@@ -41,6 +44,7 @@ public class HaxeColorSettingsPage implements ColorSettingsPage {
     new AttributesDescriptor(HaxeBundle.message("haxe.color.settings.description.block.comment"), BLOCK_COMMENT),
     new AttributesDescriptor(HaxeBundle.message("haxe.color.settings.description.doc.comment"), DOC_COMMENT),
     new AttributesDescriptor(HaxeBundle.message("haxe.color.settings.description.conditional.compilation"), CONDITIONALLY_NOT_COMPILED),
+    new AttributesDescriptor(HaxeBundle.message("haxe.color.settings.description.unparseable.data"), UNPARSEABLE_DATA),
     new AttributesDescriptor(HaxeBundle.message("haxe.color.settings.description.conditional.compilation.defined.flag"), DEFINED_VAR),
     new AttributesDescriptor(HaxeBundle.message("haxe.color.settings.description.conditional.compilation.undefined.flag"), UNDEFINED_VAR),
     new AttributesDescriptor(HaxeBundle.message("haxe.color.settings.description.keyword"), KEYWORD),
@@ -66,11 +70,15 @@ public class HaxeColorSettingsPage implements ColorSettingsPage {
 
   @NonNls private static final Map<String, TextAttributesKey> ourTags = new HashMap<String, TextAttributesKey>();
 
+  /* These strings define what token will be highlighted and selected when the code
+     screen is focused/clicked upon in the settings dialog.
+   */
   static {
     ourTags.put("parameter", PARAMETER);
     ourTags.put("local.variable", LOCAL_VARIABLE);
     ourTags.put("class", CLASS);
     ourTags.put("compilation", CONDITIONALLY_NOT_COMPILED);
+    ourTags.put("unparseable", UNPARSEABLE_DATA);
     ourTags.put("defined.flag", DEFINED_VAR);
     ourTags.put("undefined.flag", UNDEFINED_VAR);
     ourTags.put("interface", INTERFACE);
@@ -141,9 +149,12 @@ public class HaxeColorSettingsPage implements ColorSettingsPage {
            "    var <local.variable>reassignedValue</local.variable>:<class>Int</class> = <class>SomeClass</class>.<static.member.variable>staticField</static.member.variable>; \n" +
            "    <local.variable>reassignedValue</local.variable> ++; \n" +
            "    function localFunction() {\n" +
-           "      var <local.variable>a</local.variable>:<class>Int</class> = $$$;// bad character\n" +
+           "      var <local.variable>a</local.variable>:<class>Int</class> = \\?;// bad character `\\` \n" +
            "    };\n" +
            "  }\n" +
-           "}";
+           "}\n" +
+           "/* The next line is deliberately invalid syntax to show unparsable data. */\n" +
+           "<unparseable>var $.{}{}</unparseable>"
+           ;
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/highlight/HaxeSyntaxHighlighter.java
+++ b/src/common/com/intellij/plugins/haxe/ide/highlight/HaxeSyntaxHighlighter.java
@@ -2,6 +2,7 @@
  * Copyright 2000-2013 JetBrains s.r.o.
  * Copyright 2014-2014 AS3Boyan
  * Copyright 2014-2014 Elias Ku
+ * Copyright 2019 Eric Bishton
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +18,7 @@
  */
 package com.intellij.plugins.haxe.ide.highlight;
 
+import com.intellij.lang.parser.GeneratedParserUtilBase;
 import com.intellij.lexer.Lexer;
 import com.intellij.openapi.editor.colors.TextAttributesKey;
 import com.intellij.openapi.fileTypes.SyntaxHighlighterBase;
@@ -73,6 +75,8 @@ public class HaxeSyntaxHighlighter extends SyntaxHighlighterBase {
 
     fillMap(ATTRIBUTES, BAD_TOKENS, HaxeSyntaxHighlighterColors.BAD_CHARACTER);
     fillMap(ATTRIBUTES, CONDITIONALLY_NOT_COMPILED, HaxeSyntaxHighlighterColors.CONDITIONALLY_NOT_COMPILED);
+
+    ATTRIBUTES.put(GeneratedParserUtilBase.DUMMY_BLOCK, HaxeSyntaxHighlighterColors.UNPARSEABLE_DATA);
   }
 
   @NotNull

--- a/src/common/com/intellij/plugins/haxe/ide/highlight/HaxeSyntaxHighlighterColors.java
+++ b/src/common/com/intellij/plugins/haxe/ide/highlight/HaxeSyntaxHighlighterColors.java
@@ -38,6 +38,7 @@ public class HaxeSyntaxHighlighterColors {
   public static final String HAXE_PARAMETER = "HAXE_PARAMETER";
   public static final String HAXE_DEFINED_VAR = "HAXE_DEFINED_VAR";
   public static final String HAXE_UNDEFINED_VAR = "HAXE_UNDEFINED_VAR";
+  public static final String HAXE_UNPARSEABLE_DATA = "HAXE_UNPARSEABLE_DATA";
 
   public static final TextAttributesKey LINE_COMMENT =
     createTextAttributesKey("HAXE_LINE_COMMENT", DefaultLanguageHighlighterColors.LINE_COMMENT);
@@ -49,6 +50,7 @@ public class HaxeSyntaxHighlighterColors {
   public static final TextAttributesKey DEFINED_VAR = createTextAttributesKey("HAXE_DEFINED_VAR");
   public static final TextAttributesKey UNDEFINED_VAR = createTextAttributesKey("HAXE_UNDEFINED_VAR");
   public static final TextAttributesKey CONDITIONALLY_NOT_COMPILED = createTextAttributesKey("HAXE_CONDITIONALLY_NOT_COMPILED");
+  public static final TextAttributesKey UNPARSEABLE_DATA = createTextAttributesKey(HAXE_UNPARSEABLE_DATA);
 
   public static final TextAttributesKey KEYWORD =
     createTextAttributesKey("HAXE_KEYWORD", DefaultLanguageHighlighterColors.KEYWORD);

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
@@ -328,7 +328,7 @@ public class HaxeExpressionEvaluator {
       boolean resolved = !typeHolder.getType().isUnknown();
       for (int n = 1; n < children.length; n++) {
         String accessName = children[n].getText();
-        if (typeHolder.getType().isString() && typeHolder.getType().isConstant() && accessName.equals("code")) {
+        if (typeHolder.getType().isString() && typeHolder.getType().isConstant() && "code".equals(accessName)) {
           String str = (String)typeHolder.getType().getConstant();
           typeHolder = SpecificTypeReference.getInt(element, (str != null && str.length() >= 1) ? str.charAt(0) : -1).createHolder();
           if (str == null || str.length() != 1) {


### PR DESCRIPTION
This highlights the PsiDummy blocks that are created when the parser fails.  It helps (me, at least) to know why completion, refactoring, etc. aren't working when I've got invalid code sequences that I'm in the middle of editing.  Some folks might find it annoying, and they can turn it off by unchecking the boxes for "Unparseable Data" in the Settings->Editor->ColorScheme->Haxe settings panel.  The default colors work well in both IntelliJ and Darcula themes.  It's a bit brash for the High-Contrast theme (but it _is_ high contrast!).