### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,40 @@
-sudo: required
 language: java
 install:
   - true
-env:
-  - IDEA_VERSION=2016.3.8
-  - IDEA_VERSION=2017.3.5
-  - IDEA_VERSION=2018.2.8
-  - IDEA_VERSION=2019.1.3
-  - IDEA_VERSION=2019.2
-os:
-  - linux
-  - osx
 
-# Null (blank) options allow us to create a larger matrix, from which we can exclude invalid options.
-osx_image: 
-  - xcode9.3
-  - 
-jdk: 
-  - openjdk8
-  -
+# We had to remove the matrix and list the builds by hand because Travis
+# changed how blank dashes in a key were used (caused errors, but empty
+# strings worked better), and osx will fail to parse this file if a mac
+# target has a jdk entry.
+jobs:
+  include:
+    - os: osx
+      osx_image: xcode9.3
+      env: IDEA_VERSION=2019.2
 
-# Excluding allows us to remove specific sets from the matrix.  In this case, it is imperative
-# that we do NOT include any jdk: for osx.  The secondary goal of removing xcode from linux
-# builds is mostly cosmetic.
-matrix:
-  exclude:
-  - os: osx
-    jdk: openjdk8
-  - os: osx
-    osx_image:
-  - os: linux
-    jdk:
-  - os: linux
-    osx_image: xcode9.3
+    - os: linux
+      env: IDEA_VERSION=2019.2
+      jdk: openjdk8
+    - os: linux
+      env: IDEA_VERSION=2019.1.3
+      jdk: openjdk8
+    - os: linux
+      env: IDEA_VERSION=2018.2.8
+      jdk: openjdk8
+    - os: linux
+      env: IDEA_VERSION=2017.3.5
+      jdk: openjdk8
+    - os: linux
+      env: IDEA_VERSION=2016.3.8
+      jdk: openjdk8
+
+    # Build and push the nightly (EAP) version.
+    - if: branch = develop AND type = push
+      script: make
+      env:
+        - IDEA_VERSION=2018.1.6 PLUGIN_VERSION=18 DEV_BUILD=.dev.${TRAVIS_COMMIT::7}
+      after_success:
+        - curl -k -i -F "userName=$PLUGIN_USER_NAME" -F "password=$PLUGIN_USER_PASS" -F channel=EAP -F pluginId=6873 -F "file=@intellij-haxe-$PLUGIN_VERSION.jar" https://plugins.jetbrains.com/plugin/uploadPlugin
 
 
 before_script: |
@@ -57,14 +59,5 @@ before_script: |
 script:
 - ./gradlew clean Build verifyPlugin -PgenerateHxcppDebugger=false -PtargetVersion=$IDEA_VERSION -PdevBuild=$DEV_BUILD
 
-
 notifications:
-email: false
-jobs:
-  include:
-    - if: branch = develop AND type = push
-      script: make
-      env:
-        - IDEA_VERSION=2018.1.6 PLUGIN_VERSION=18 DEV_BUILD=.dev.${TRAVIS_COMMIT::7}
-      after_success:
-        - curl -k -i -F "userName=$PLUGIN_USER_NAME" -F "password=$PLUGIN_USER_PASS" -F channel=EAP -F pluginId=6873 -F "file=@intellij-haxe-$PLUGIN_VERSION.jar" https://plugins.jetbrains.com/plugin/uploadPlugin
+  email: false


### PR DESCRIPTION
Unrolls the matrix and lists all intended builds specifically.
Also, creates fewer mac builds.