### PR TITLE
Allow immediate access of array literals.

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -576,6 +576,7 @@ left suffixExpression ::= suffixOperator
 private value ::= ('untyped' expression)
                 | 'macro' expression
                 | callFunctionLiteral
+                | immediateArrayAccess
                 | (literalExpression qualifiedReferenceTail?)
                 | callOrArrayAccess
                 | ifStatement
@@ -626,6 +627,7 @@ private qualifiedReferenceTail ::= qualifiedReferenceExpression (callExpression 
 
 private callFunctionLiteral ::= functionLiteral callExpression
 private callOrArrayAccess ::= (referenceExpression | thisExpression | superExpression | parenthesizedExpression) (callExpression | arrayAccessExpression | qualifiedReferenceExpression)*
+private immediateArrayAccess ::= arrayLiteral arrayAccessExpression
 
 left callExpression ::= '(' expressionList? ')'
 {mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeReference" name="function call"}

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -93,6 +93,7 @@
             <li>Add UI to allow reformatting and color options.</li>
           </ul>
         </li>
+        <li>Allow immediate array accesses on literal arrays. (e.g. var a=["1","2"][1];)</li>
         <li>Fix several issues with type checking, particularly when generics are involved.</li>
         <li>Allow non-standard orderings of class and method modifiers (e.g. final, private, extern) and warn on duplicates.</li>
         <li>Recover from circular class dependencies.</li>

--- a/testData/annotation.semantic/AssignReflectionTypeToDynamic.hx
+++ b/testData/annotation.semantic/AssignReflectionTypeToDynamic.hx
@@ -1,0 +1,8 @@
+package;
+class Test {
+    static function main() {
+        trace("Haxe is great!");
+
+        var instance:Dynamic = Type.createInstance(Test, []);
+    }
+}

--- a/testData/annotation.semantic/ImmediateStringArrayIndexing.hx
+++ b/testData/annotation.semantic/ImmediateStringArrayIndexing.hx
@@ -1,0 +1,8 @@
+package;
+class Test {
+  public static function main() {
+    var round:Int = 1;
+    var str:String = ["LdrBtnIconB", "LdrBtnIconS", "LdrBtnIconG"][round]; // Error was: "Incompatible type: Array<String> should be String"
+    trace(str);
+  }
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -513,4 +513,13 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
   public void testParameterizedFunctions() throws Exception {
     doTestNoFixWithWarnings();
   }
+
+  public void testImmediateStringArrayIndexing() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
+  //Issue #981
+  public void testAssignReflectionTypeToDynamic() throws Exception {
+    doTestNoFixWithWarnings();
+  }
 }


### PR DESCRIPTION
Allows immediate access of array literals:
```Haxe
class TestImmediateStringArrayIndexing {
    public static function main() {
        var round:Int = 1;
        var str:String = [ "LdrBtnIconB", "LdrBtnIconS", "LdrBtnIconG"][round]; // Error was: "Incompatible type: Array<String> should be String"
        trace(str);
    }
}
```