### PR TITLE
Adding support for "IS" keyword

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -528,7 +528,7 @@ expressionList ::= forStatement | whileStatement | (expression (',' expression)*
 private expression_list_recover ::= !(')' | ']')
 
 expression ::= assignExpressionWrapper {recoverWhile="expression_recover" name="expression"}
-private expression_recover ::= !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<<' | '<<=' | '<=' | '=' | '==' | '>' | <<shiftRight>> | <<unsignedShiftRight>> | <<gtEq>> | <<shiftRightAssign>> | <<unsignedShiftRightAssign>> | '?' | metaKeyWord | '[' | ']' | '^' | '^=' | 'break' | 'case' | 'cast' | 'catch' | 'continue' | 'default' | 'do' | 'dynamic' | 'else' | 'false' | 'final' | 'for' | 'function' | 'if' | 'inline' | 'new' | 'null' | 'override' | 'private' | 'public' | 'return' | 'static' | 'super' | 'switch' | 'this' | 'throw' | 'true' | 'try' | 'untyped' | 'var' | 'while' | '{' | '|' | '|=' | '||' | '}' | '~' | ID | LITFLOAT | LITHEX | LITINT | LITOCT | OPEN_QUOTE | CLOSING_QUOTE | META_ID | REG_EXP | LONG_TEMPLATE_ENTRY_END | '=>')
+private expression_recover ::= !('!' | '!=' | '%' | '%=' | '&&' | '&' | '&=' | '(' | ')' | '*' | '*=' | '+' | '++' | '+=' | ',' | '-' | '--' | '-=' | '.' | '...' | '/' | '/=' | ':' | ';' | '<' | '<<' | '<<=' | '<=' | '=' | '==' | '>' | <<shiftRight>> | <<unsignedShiftRight>> | <<gtEq>> | <<shiftRightAssign>> | <<unsignedShiftRightAssign>> | '?' | metaKeyWord | '[' | ']' | '^' | '^=' | 'break' | 'case' | 'cast' | 'catch' | 'continue' | 'default' | 'do' | 'dynamic' | 'else' | 'false' | 'final' | 'for' | 'function' | 'if' | 'inline' | 'new' | 'null' | 'override' | 'private' | 'public' | 'return' | 'static' | 'super' | 'switch' | 'this' | 'throw' | 'true' | 'try' | 'untyped' | 'var' | 'while' | '{' | '|' | '|=' | '||' | '}' | '~' | ID | LITFLOAT | LITHEX | LITINT | LITOCT | OPEN_QUOTE | CLOSING_QUOTE | META_ID | REG_EXP | LONG_TEMPLATE_ENTRY_END | '=>' | isTypeOperator)
 
 private assignExpressionWrapper ::= iteratorExpressionWrapper assignExpression?
 left assignExpression ::= assignOperation iteratorExpressionWrapper { pin=2 }
@@ -537,10 +537,14 @@ private iteratorExpressionWrapper ::= ternaryExpressionWrapper iteratorExpressio
 private iteratorOperator ::= '...'
 left iteratorExpression ::= iteratorOperator ternaryExpressionWrapper {pin=2}
 
-private ternaryExpressionWrapper ::= logicOrExpressionWrapper ternaryExpression?
+private ternaryExpressionWrapper ::= isTypeExpressionWrapper ternaryExpression?
 private ternaryFirstOperator ::= '?'
 private ternarySecondOperator ::= ':'
 left ternaryExpression ::= ternaryFirstOperator expression ternarySecondOperator ternaryExpressionWrapper {pin=2}
+
+private isTypeExpressionWrapper ::= logicOrExpressionWrapper isTypeExpression?
+private isTypeOperator ::= 'is'
+left isTypeExpression ::= isTypeOperator typeWrapper | '(' isTypeOperator typeWrapper ')' logicOrExpressionWrapper? {pin=2}
 
 private logicOrExpressionWrapper ::= logicAndExpressionWrapper logicOrExpression*
 private logicOrExpressionOperator ::= '||'


### PR DESCRIPTION
Haxe 4 has added support of  the `is` keyword and its is (as far as i know) going to replace `Std.is` in haxe 4.2.
This pull-request will make the haxe parser understand  the  `is` keyword at a very basic level. 

![image](https://user-images.githubusercontent.com/3193925/92333610-30e84100-f087-11ea-9580-894d0c402b10.png)


keyword highlighting is currently missing as regenerating the `haxe.flex` caused the following tests to fail.
```
testNoErrorOnOptionalParameterWithSimpleStringFieldConstant
testNoErrorOnOptionalParameterWithParenthesizedStringFieldConstant
testNoErrorOnOptionalParameterWithParenthesizedNumericFieldConstant
testTypeErrorOnOptionalParameterWithParenthesizedNumericFieldConstant
```

but the highlighting works,  i just don't want to commit changes that breaks tests.

![image](https://user-images.githubusercontent.com/3193925/92334644-38f8ae80-f090-11ea-9ec5-68610772bf9b.png)


the difference in my  code that got for highlighting is just:
**In `haxe.bnf`**
add
```
 kIS="is"
```
before
```
 kVAR="var"
```

**in `HaxeTokenTypeSets.java`** 
and added "KIS" to the KEYWORDS Tokenset 

**in `haxe.flex`**
add
```
"is"                                     {  return emitToken( KIS);  }
```
before
```
"var"                                     {  return emitToken( KVAR);  }
```

