### PR TITLE
Adding Darcula color scheme and removing foreground color change

### DIFF
--- a/resources/colorSchemes/HaxeDarcula.xml
+++ b/resources/colorSchemes/HaxeDarcula.xml
@@ -1,9 +1,8 @@
 <?xml version='1.0'?>
 <!--
   ~ Copyright 2000-2013 JetBrains s.r.o.
-  ~ Copyright 2014-2014 AS3Boyan
+  ~ Copyright 2014-2020 AS3Boyan
   ~ Copyright 2014-2014 Elias Ku
-  ~ Copyright 2019 Eric Bishton
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -36,7 +35,7 @@
   </option>
   <option name="HAXE_UNPARSEABLE_DATA">
     <value>
-      <option name="BACKGROUND" value="F0F0F0"/>
+      <option name="BACKGROUND" value="3C3C3C"/>
     </value>
   </option>
 </list>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1028,7 +1028,7 @@
                         serviceImplementation="com.intellij.plugins.haxe.ide.folding.HaxeFoldingSettings"/>
 
     <additionalTextAttributes scheme="Default" file="colorSchemes/HaxeDefault.xml"/>
-    <additionalTextAttributes scheme="Darcula" file="colorSchemes/HaxeDefault.xml"/>
+    <additionalTextAttributes scheme="Darcula" file="colorSchemes/HaxeDarcula.xml"/>
 
     <codeStyleSettingsProvider implementation="com.intellij.plugins.haxe.ide.formatter.settings.HaxeCodeStyleSettingsProvider"/>
     <langCodeStyleSettingsProvider implementation="com.intellij.plugins.haxe.ide.formatter.settings.HaxeLanguageCodeStyleSettingsProvider"/>


### PR DESCRIPTION
I want to suggest splitting up the colorSchemes into light(default) and dark(darcula) and remove the  foreground color change for unparsable data, (i feel like it makes my code easier to read)

![image](https://user-images.githubusercontent.com/3193925/94739711-ad61fd00-0371-11eb-84b3-07a6cbcda9ab.png)

_**HighContrast,  Default,  Darcula**_

**Note**: HighContrast inherits from Darcula  and i have not found a way to override this.