### PR TITLE
Adding recovery for `ForStatement`

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -469,9 +469,12 @@ private notBlockStatement ::= ('untyped' statement ';'?)
                             | tryStatement
                             | expression
 
-forStatement ::= 'for' '(' forDeclaration 'in' iterable')' statement ';'?
-{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeForStatementPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeForStatementPsiMixin"}
+
+forStatement ::= 'for' '(' iterableDeclaration ')' statement ';'?
+{recoverWhile=forStatement_recover mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeForStatementPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeForStatementPsiMixin"}
 // XXX: Somehow or another, forStatement must derive from AbstractHaxeNamedComponent, or variable resolution will break.
+private iterableDeclaration ::= forDeclaration 'in' iterable {pin=1 recoverWhile="iterable_decl_recovery"}
+private iterable_decl_recovery ::= !(')')
 private forDeclaration ::= keyValueIterator | componentName
 iteratorkey ::= componentName
 {mixin="com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeNamedComponent" implements="com.intellij.plugins.haxe.lang.psi.HaxeComponent"}


### PR DESCRIPTION
Adding recovery for `for loops` so we don't have to display unparsable data.
Tested With:
```haxe
 class HighlightTest {

    public function new() {}

    public function testForLoop()  {
        var r = ["1", "2", "3"];
        // CORRECT USE
        for(a in r)     {var f:String = "string";}
        var x = "";

        //WRONG USE
        for(a+ in -r)   {var f:String = "string";}
        var x = "";
        
        for(a : r)      {var f:String = "string";}
        var x = "";

        for(?)          {var f:String = "string";}
        var x = "";
        
        var c = ["v1" =>"V2"];

        // CORRECT USE
        for(a => b in c)     {var f:String = "string";}
        var x = "";

        //WRONG USE
        for(a => b : b)     {var f:String = "string";}
        var x = "";

        for(a => b in !)    {var f:String = "string";}
        var x = "";

        for(a ! b in c)     {var f:String = "string";}
        var x = "";

    }
}
```