### PR TITLE
Feature/abstract implicit cast support

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -85,6 +85,7 @@
       <p>Unreleased changes</p>
       <ul>
         <li>Recognize and use static extensions having unifiable (assignable) types. (Issue #964)</li>
+        <li>Recognize implicit cast methods in Abstracts (Methods annotated with @:to / @From)</li>
       </ul>
       <p>1.3.1 (HaxeFoundation release)</p>
       <ul>

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -402,6 +402,7 @@ class TypeTagChecker {
   ) {
     final ResultHolder varType = HaxeTypeResolver.getTypeFromTypeTag(tag, erroredElement);
     final ResultHolder initType = getTypeFromVarInit(initExpression);
+    initType.setInitExpression();
 
     if (!varType.canAssign(initType)) {
 

--- a/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/info/HaxeParameterInfoHandler.java
@@ -25,7 +25,6 @@ import com.intellij.openapi.util.Condition;
 import com.intellij.plugins.haxe.HaxeComponentType;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
-import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
 import com.intellij.plugins.haxe.model.type.HaxeGenericResolverUtil;
 import com.intellij.plugins.haxe.model.type.HaxeTypeResolver;
 import com.intellij.plugins.haxe.model.type.ResultHolder;

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -222,7 +222,7 @@ public class HaxeClassModel implements HaxeExposableModel {
   }
 
 
-  private boolean castMethodAcceptsSource(SpecificHaxeClassReference reference, HaxeMethodModel methodModel) {
+  private boolean castMethodAcceptsSource(@NotNull SpecificHaxeClassReference reference, @NotNull HaxeMethodModel methodModel) {
     SpecificHaxeClassReference parameter = getTypeOfFirstParameter(methodModel);
     //implicit cast methods seems to accept both parameter-less methods and single parameter methods
     if (parameter == null) return true; // if no param then "this" is  the  input  and will always be compatible.
@@ -248,14 +248,15 @@ public class HaxeClassModel implements HaxeExposableModel {
       .collect(toList());
   }
 
-
-  private SpecificHaxeClassReference getImplicitCastFromType(HaxeMethodModel methodModel) {
+  @Nullable
+  private SpecificHaxeClassReference getImplicitCastFromType(@NotNull HaxeMethodModel methodModel) {
     SpecificHaxeClassReference parameter = getTypeOfFirstParameter(methodModel);
     if (parameter == null) return null;
     return SetSpecificsConstraints(methodModel, parameter);
   }
 
-  private SpecificHaxeClassReference SetSpecificsConstraints(HaxeMethodModel methodModel, SpecificHaxeClassReference classReference) {
+  @NotNull
+  private SpecificHaxeClassReference SetSpecificsConstraints(@NotNull HaxeMethodModel methodModel, @NotNull SpecificHaxeClassReference classReference) {
     ResultHolder[] specifics = classReference.getGenericResolver().getSpecifics();
     ResultHolder[] newSpecifics = applyConstraintsToSpecifics(methodModel, specifics);
 
@@ -264,28 +265,32 @@ public class HaxeClassModel implements HaxeExposableModel {
   }
 
   //caching  implicit cast  method lookup results
+  @NotNull
   private List<HaxeMethodModel> getCastToMethods() {
     if (castToMethods != null) return castToMethods;
     castToMethods = getMethodsWithMetadata(haxeClass.getModel(), "to", HaxeMeta.COMPILE_TIME, null);
     return castToMethods;
   }
   //caching implicit cast method lookup  results
+  @NotNull
   private List<HaxeMethodModel> getCastFromMethods() {
     if (castFromMethods != null) return castFromMethods;
     castFromMethods = getMethodsWithMetadata(haxeClass.getModel(), "from", HaxeMeta.COMPILE_TIME, null);
     return castFromMethods;
   }
 
-  private SpecificHaxeClassReference getReturnType(HaxeMethodModel model) {
-    return model.getFunctionType().getReturnType().getClassType();
+  @NotNull
+  private SpecificHaxeClassReference getReturnType(@NotNull HaxeMethodModel model) {
+    SpecificHaxeClassReference type = model.getFunctionType().getReturnType().getClassType();
+    return type != null ? type :  SpecificTypeReference.getUnknown(model.getFunctionType().getReturnType().getElementContext());
   }
 
-  private SpecificHaxeClassReference getTypeOfFirstParameter(HaxeMethodModel model) {
+  @Nullable
+  private SpecificHaxeClassReference getTypeOfFirstParameter(@NotNull HaxeMethodModel model) {
     List<SpecificFunctionReference.Argument> arguments = model.getFunctionType().getArguments();
     if (arguments.isEmpty()) return null;
 
-    SpecificHaxeClassReference argumentType = arguments.get(0).getType().getClassType();
-    return argumentType;
+    return arguments.get(0).getType().getClassType();
   }
 
 

--- a/src/common/com/intellij/plugins/haxe/model/HaxeGenericParamModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeGenericParamModel.java
@@ -74,6 +74,7 @@ public class HaxeGenericParamModel {
       else {
         // Anonymous struct for a constraint.
         // TODO: Turn the anonymous structure into a ResolveResult.
+        return HaxeTypeResolver.getPsiElementType(toa.getOriginalElement(),  resolver); //temp solution
       }
     }
     return null;

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
@@ -273,8 +273,10 @@ public class HaxeTypeCompatible {
             if (!canAssignToFrom(toSpecific, fromSpecific)) {
               if(initExpression) {
                 //HACK make sure we can assign collection literals / init expressions to types with with EnumValue specific
-                if (toSpecific.isEnumValueClass() && fromSpecific.isEnumClass()) return true;
-                if (fromSpecific.isEnumValueClass() && toSpecific.isEnumClass()) return true;
+                if(toSpecific != null  && fromSpecific!= null) {
+                  if (toSpecific.isEnumValueClass() && fromSpecific.isEnumClass()) return true;
+                  if (fromSpecific.isEnumValueClass() && toSpecific.isEnumClass()) return true;
+                }
               }
               return false;
             }

--- a/src/common/com/intellij/plugins/haxe/model/type/ResultHolder.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/ResultHolder.java
@@ -31,7 +31,7 @@ public class ResultHolder {
 
   @NotNull
   private SpecificTypeReference type;
-
+  private boolean initExpression = false;
   private boolean canMutate = true;
   private int mutationCount = 0;
 
@@ -75,7 +75,7 @@ public class ResultHolder {
     return type.isDynamic();
   }
 
-  boolean initExpression = false;
+
   public boolean isInitExpression() {
     return initExpression;
   }

--- a/src/common/com/intellij/plugins/haxe/model/type/ResultHolder.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/ResultHolder.java
@@ -75,6 +75,14 @@ public class ResultHolder {
     return type.isDynamic();
   }
 
+  boolean initExpression = false;
+  public boolean isInitExpression() {
+    return initExpression;
+  }
+  public void setInitExpression() {
+    initExpression = true;
+  }
+
   public boolean canBeTypeVariable() {
     return type.canBeTypeVariable();
   }

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
@@ -24,6 +24,7 @@ import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeNamedComponent;
 import com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxeTypeDefImpl;
 import com.intellij.plugins.haxe.metadata.HaxeMetadataList;
+import com.intellij.plugins.haxe.metadata.psi.HaxeMeta;
 import com.intellij.plugins.haxe.metadata.util.HaxeMetadataUtils;
 import com.intellij.plugins.haxe.model.*;
 import com.intellij.plugins.haxe.util.HaxeDebugUtil;
@@ -32,6 +33,9 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
 
 public class SpecificHaxeClassReference extends SpecificTypeReference {
   private static final String CONSTANT_VALUE_DELIMITER = " = ";
@@ -271,7 +275,7 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
     stack.push(model.haxeClass);
 
     //TODO: this is a workaround for map classes  until @:multiType  & @:followWithAbstracts support is implemented
-    list.addAll(getCompatibleMapTypes(model, genericResolver, direction));
+    //list.addAll(getCompatibleMapTypes(model, genericResolver, direction));
 
     // TODO: list.addAll(getCompatibleFunctionTypes(model, genericResolver));
     list.addAll(emptyCollectionAssignment(direction));
@@ -351,6 +355,10 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
       return resolve instanceof HaxeClass;
     }
     return false;
+  }
+
+  public boolean isTypeDef() {
+    return clazz instanceof HaxeTypedefDeclaration;
   }
 
   public boolean isCoreType() {
@@ -542,7 +550,7 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
   }
 
   @NotNull
-  ResultHolder[] getSpecifics() {
+  public ResultHolder[] getSpecifics() {
     return specifics;
   }
 

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
@@ -274,9 +274,6 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
     if (stack.contains(model.haxeClass)) return list;
     stack.push(model.haxeClass);
 
-    //TODO: this is a workaround for map classes  until @:multiType  & @:followWithAbstracts support is implemented
-    //list.addAll(getCompatibleMapTypes(model, genericResolver, direction));
-
     // TODO: list.addAll(getCompatibleFunctionTypes(model, genericResolver));
     list.addAll(emptyCollectionAssignment(direction));
 

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
@@ -172,6 +172,7 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
       for (int n = 0; n < params.size(); n++) {
         HaxeGenericParamModel paramModel = params.get(n);
         ResultHolder specific = (n < getSpecifics().length) ? this.getSpecifics()[n] : getUnknown(context).createHolder();
+        if(specific == null)  specific = getUnknown(context).createHolder();// null safety
         resolver.add(paramModel.getName(), specific);
       }
     }
@@ -269,9 +270,10 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
     if (stack.contains(model.haxeClass)) return list;
     stack.push(model.haxeClass);
 
+    //TODO: this is a workaround for map classes  until @:multiType  & @:followWithAbstracts support is implemented
     list.addAll(getCompatibleMapTypes(model, genericResolver, direction));
+
     // TODO: list.addAll(getCompatibleFunctionTypes(model, genericResolver));
-    list.addAll(getCompatibleEnumTypes(model, genericResolver));
     list.addAll(emptyCollectionAssignment(direction));
 
     if (!model.isAbstract()) {
@@ -535,7 +537,7 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
   }
 
   @NotNull
-  HaxeClassReference getHaxeClassReference() {
+  public HaxeClassReference getHaxeClassReference() {
     return classReference;
   }
 

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
@@ -19,10 +19,7 @@
  */
 package com.intellij.plugins.haxe.model.type;
 
-import com.intellij.plugins.haxe.lang.psi.HaxeAnonymousType;
-import com.intellij.plugins.haxe.lang.psi.HaxeClass;
-import com.intellij.plugins.haxe.lang.psi.HaxeEnumDeclaration;
-import com.intellij.plugins.haxe.lang.psi.HaxeEnumValueDeclaration;
+import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.lang.psi.impl.HaxeDummyASTNode;
 import com.intellij.plugins.haxe.lang.psi.impl.HaxePsiCompositeElementImpl;
 import com.intellij.plugins.haxe.model.HaxeClassModel;
@@ -282,6 +279,16 @@ public abstract class SpecificTypeReference {
   /** Tell whether the class is the Enum<type> abstract class. */
   final public boolean isEnumClass() {
     return isNamedType(ENUM);
+  }
+  final public boolean isClass() {
+    return isNamedType(CLASS);
+  }
+  final public boolean isAbstract() {
+    if (this instanceof SpecificHaxeClassReference) {
+      final SpecificHaxeClassReference reference = (SpecificHaxeClassReference)this;
+      return reference.getHaxeClass() instanceof  HaxeAbstractClassDeclaration;
+    }
+    return false;
   }
 
   final public boolean isEnumValue() {

--- a/src/common/com/intellij/plugins/haxe/util/HaxeGenericUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeGenericUtil.java
@@ -1,3 +1,16 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.intellij.plugins.haxe.util;
 
 import com.intellij.plugins.haxe.model.HaxeGenericParamModel;
@@ -17,58 +30,54 @@ import static java.util.stream.Collectors.toMap;
 public class HaxeGenericUtil {
 
   public static SpecificHaxeClassReference convertGenericType(HaxeMethodModel model, SpecificHaxeClassReference classReference) {
-    if (nonNull(model.getGenericParams())) {
+    List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+    if (nonNull(genericParams)) {
 
-      List<HaxeGenericParamModel> genericParams = model.getGenericParams();
       ResultHolder[] specifics = classReference.getGenericResolver().getSpecifics();
 
-      if (genericParams != null) {
-        Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
-        ResultHolder[] newSpecifics = new ResultHolder[specifics.length];
+      Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
+      ResultHolder[] newSpecifics = new ResultHolder[specifics.length];
 
-        for (int i = 0; i < specifics.length; i++) {
-          String name = specifics[i].getClassType().getClassName();
-          boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
-          if (nameFound) {
-            if (nameAndConstraints.containsKey(name)) {
-              newSpecifics[i] = nameAndConstraints.get(name);
-              continue;
-            }
+      for (int i = 0; i < specifics.length; i++) {
+        String name = specifics[i].getClassType().getClassName();
+        boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
+        if (nameFound) {
+          if (nameAndConstraints.containsKey(name)) {
+            newSpecifics[i] = nameAndConstraints.get(name);
+            continue;
           }
-          newSpecifics[i] = specifics[i];
         }
-        return SpecificHaxeClassReference.withGenerics(classReference.getHaxeClassReference(), newSpecifics);
+        newSpecifics[i] = specifics[i];
       }
+      return SpecificHaxeClassReference.withGenerics(classReference.getHaxeClassReference(), newSpecifics);
     }
     return classReference;
   }
 
 
   public static ResultHolder[] applyConstraintsToSpecifics(HaxeMethodModel model, ResultHolder[] specifics) {
-    if (nonNull(model.getGenericParams())) {
-      List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+    List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+    if (nonNull(genericParams)) {
 
-      if (genericParams != null) {
-        Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
+      Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
 
-        for (int i = 0; i < specifics.length; i++) {
-          String name = specifics[i].getClassType().getClassName();
-          boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
-          if (nameFound) {
-            if (nameAndConstraints.containsKey(name)) {
-              specifics[i] = nameAndConstraints.get(name);
+      for (int i = 0; i < specifics.length; i++) {
+        String name = specifics[i].getClassType().getClassName();
+        boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
+        if (nameFound) {
+          if (nameAndConstraints.containsKey(name)) {
+            specifics[i] = nameAndConstraints.get(name);
 
-              // TODO hack to avoid EnumValue issues
-              //  The EnumValue type does not have any implicit cast methods and is not an Enum type yet the compiler  in some cases treats it as if it did.
-              //  We get around this issue by  replacing it with Enum<Dynamic> for now.
-              if (specifics[i].getClassType().isEnumValueClass()) {
-                ResultHolder dynamicType = SpecificTypeReference.getDynamic(model.getMethodPsi()).createHolder();
-                specifics[i] = wrapType(dynamicType, specifics[i].getElementContext(), true).createHolder();
-              }
-              continue;
+            // TODO hack to avoid EnumValue issues
+            //  The EnumValue type does not have any implicit cast methods and is not an Enum type yet the compiler  in some cases treats it as if it did.
+            //  We get around this issue by  replacing it with Enum<Dynamic> for now.
+            if (specifics[i].getClassType().isEnumValueClass()) {
+              ResultHolder dynamicType = SpecificTypeReference.getDynamic(model.getMethodPsi()).createHolder();
+              specifics[i] = wrapType(dynamicType, specifics[i].getElementContext(), true).createHolder();
             }
-            specifics[i] = SpecificTypeReference.getDynamic(model.getMethodPsi()).createHolder();
+            continue;
           }
+          specifics[i] = SpecificTypeReference.getDynamic(model.getMethodPsi()).createHolder();
         }
       }
     }
@@ -76,21 +85,19 @@ public class HaxeGenericUtil {
   }
 
   public static SpecificHaxeClassReference replaceTypeIfGenericParameterName(HaxeMethodModel model, SpecificHaxeClassReference parameter) {
-    if (nonNull(model.getGenericParams())) {
-      List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+    List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+    if (nonNull(genericParams)) {
 
-      if (genericParams != null) {
-        Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
+      Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
 
-        String name = parameter.getClassName();
-        boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
-        if (nameFound) {
-          if (nameAndConstraints.containsKey(name)) {
-            return nameAndConstraints.get(name).getClassType();
-          }
-          // if Type name is generic name  but no constraints return dynamic to accept any type assignment
-          return SpecificTypeReference.getDynamic(model.getMethodPsi());
+      String name = parameter.getClassName();
+      boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
+      if (nameFound) {
+        if (nameAndConstraints.containsKey(name)) {
+          return nameAndConstraints.get(name).getClassType();
         }
+        // if Type name is generic name  but no constraints return dynamic to accept any type assignment
+        return SpecificTypeReference.getDynamic(model.getMethodPsi());
       }
     }
     return parameter;

--- a/src/common/com/intellij/plugins/haxe/util/HaxeGenericUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeGenericUtil.java
@@ -10,6 +10,7 @@ import org.jetbrains.annotations.NotNull;
 import java.util.List;
 import java.util.Map;
 
+import static com.intellij.plugins.haxe.model.type.HaxeTypeCompatible.wrapType;
 import static java.util.Objects.nonNull;
 import static java.util.stream.Collectors.toMap;
 
@@ -56,6 +57,14 @@ public class HaxeGenericUtil {
           if (nameFound) {
             if (nameAndConstraints.containsKey(name)) {
               specifics[i] = nameAndConstraints.get(name);
+
+              // TODO hack to avoid EnumValue issues
+              //  The EnumValue type does not have any implicit cast methods and is not an Enum type yet the compiler  in some cases treats it as if it did.
+              //  We get around this issue by  replacing it with Enum<Dynamic> for now.
+              if (specifics[i].getClassType().isEnumValueClass()) {
+                ResultHolder dynamicType = SpecificTypeReference.getDynamic(model.getMethodPsi()).createHolder();
+                specifics[i] = wrapType(dynamicType, specifics[i].getElementContext(), true).createHolder();
+              }
               continue;
             }
             specifics[i] = SpecificTypeReference.getDynamic(model.getMethodPsi()).createHolder();

--- a/src/common/com/intellij/plugins/haxe/util/HaxeGenericUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeGenericUtil.java
@@ -1,0 +1,96 @@
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.plugins.haxe.model.HaxeGenericParamModel;
+import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.model.type.ResultHolder;
+import com.intellij.plugins.haxe.model.type.SpecificHaxeClassReference;
+import com.intellij.plugins.haxe.model.type.SpecificTypeReference;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.nonNull;
+import static java.util.stream.Collectors.toMap;
+
+public class HaxeGenericUtil {
+
+  public static SpecificHaxeClassReference convertGenericType(HaxeMethodModel model, SpecificHaxeClassReference classReference) {
+    if (nonNull(model.getGenericParams())) {
+
+      List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+      ResultHolder[] specifics = classReference.getGenericResolver().getSpecifics();
+
+      if (genericParams != null) {
+        Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
+        ResultHolder[] newSpecifics = new ResultHolder[specifics.length];
+
+        for (int i = 0; i < specifics.length; i++) {
+          String name = specifics[i].getClassType().getClassName();
+          boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
+          if (nameFound) {
+            if (nameAndConstraints.containsKey(name)) {
+              newSpecifics[i] = nameAndConstraints.get(name);
+              continue;
+            }
+          }
+          newSpecifics[i] = specifics[i];
+        }
+        return SpecificHaxeClassReference.withGenerics(classReference.getHaxeClassReference(), newSpecifics);
+      }
+    }
+    return classReference;
+  }
+
+
+  public static ResultHolder[] applyConstraintsToSpecifics(HaxeMethodModel model, ResultHolder[] specifics) {
+    if (nonNull(model.getGenericParams())) {
+      List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+
+      if (genericParams != null) {
+        Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
+
+        for (int i = 0; i < specifics.length; i++) {
+          String name = specifics[i].getClassType().getClassName();
+          boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
+          if (nameFound) {
+            if (nameAndConstraints.containsKey(name)) {
+              specifics[i] = nameAndConstraints.get(name);
+              continue;
+            }
+            specifics[i] = SpecificTypeReference.getDynamic(model.getMethodPsi()).createHolder();
+          }
+        }
+      }
+    }
+    return specifics;
+  }
+
+  public static SpecificHaxeClassReference replaceTypeIfGenericParameterName(HaxeMethodModel model, SpecificHaxeClassReference parameter) {
+    if (nonNull(model.getGenericParams())) {
+      List<HaxeGenericParamModel> genericParams = model.getGenericParams();
+
+      if (genericParams != null) {
+        Map<String, ResultHolder> nameAndConstraints = getGenericTypeParametersByName(genericParams);
+
+        String name = parameter.getClassName();
+        boolean nameFound = genericParams.stream().anyMatch(m -> m.getName().equals(name));
+        if (nameFound) {
+          if (nameAndConstraints.containsKey(name)) {
+            return nameAndConstraints.get(name).getClassType();
+          }
+          // if Type name is generic name  but no constraints return dynamic to accept any type assignment
+          return SpecificTypeReference.getDynamic(model.getMethodPsi());
+        }
+      }
+    }
+    return parameter;
+  }
+
+  @NotNull
+  private static Map<String, ResultHolder> getGenericTypeParametersByName(List<HaxeGenericParamModel> genericParams) {
+    return genericParams.stream()
+      .filter(mo -> nonNull(mo.getConstraint(null)))
+      .collect(toMap(HaxeGenericParamModel::getName, m -> m.getConstraint(null)));
+  }
+}

--- a/src/common/com/intellij/plugins/haxe/util/HaxeMetadataUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeMetadataUtil.java
@@ -1,0 +1,29 @@
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.plugins.haxe.metadata.HaxeMetadataList;
+import com.intellij.plugins.haxe.metadata.psi.HaxeMeta;
+import com.intellij.plugins.haxe.model.HaxeClassModel;
+import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class HaxeMetadataUtil {
+
+  public static List<HaxeMethodModel> getMethodsWithMetadata(HaxeClassModel classModel, @Nullable String metadataName,
+                                                             @Nullable Class<? extends HaxeMeta> metadataType,
+                                                             @Nullable HaxeGenericResolver resolver) {
+
+    List<HaxeMethodModel> methodModels = new LinkedList<>();
+    for (HaxeMethodModel methodModel : classModel.getMethods(resolver)) {
+      HaxeMetadataList metadataList = methodModel.getMethodPsi().getMetadataList(metadataType);
+      boolean gotFromMetadata = metadataList.stream().anyMatch(a -> metadataName == null  || a.isType(metadataName));
+      if (gotFromMetadata) {
+        methodModels.add(methodModel);
+      }
+    }
+    return methodModels;
+  }
+}

--- a/src/common/com/intellij/plugins/haxe/util/HaxeMetadataUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeMetadataUtil.java
@@ -5,6 +5,7 @@ import com.intellij.plugins.haxe.metadata.psi.HaxeMeta;
 import com.intellij.plugins.haxe.model.HaxeClassModel;
 import com.intellij.plugins.haxe.model.HaxeMethodModel;
 import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.LinkedList;
@@ -12,7 +13,7 @@ import java.util.List;
 
 public class HaxeMetadataUtil {
 
-  public static List<HaxeMethodModel> getMethodsWithMetadata(HaxeClassModel classModel, @Nullable String metadataName,
+  public static List<HaxeMethodModel> getMethodsWithMetadata(@NotNull HaxeClassModel classModel, @Nullable String metadataName,
                                                              @Nullable Class<? extends HaxeMeta> metadataType,
                                                              @Nullable HaxeGenericResolver resolver) {
 

--- a/testData/annotation.semantic/AbstractFromToMetadata.hx
+++ b/testData/annotation.semantic/AbstractFromToMetadata.hx
@@ -1,0 +1,39 @@
+package ;
+class ToFromAnnotations {
+    public function new() {
+    }
+    public function test() {
+
+        // OK; got @:from Metadata on method to convert
+        var assignFrom:MyAbstract = "3" ;
+        // OK; got @:to Metadata on method to convert
+        var assignTo:Array<Int> = assignFrom ;
+
+        // WRONG: while an abstract of int it can not be assigned to an int
+        var <error descr="Incompatible type: Int should be MyAbstract">wrongUse1:MyAbstract = 1</error>;
+        // WRONG:  while an abstract of int its not a int value
+        var <error descr="Incompatible type: MyAbstract should be Int">wrongUse2:Int = assignFrom</error>;
+
+        //  OK: Any has @:to method with Type Parameter T, all types are accepted
+        var anyVar:Any = assignFrom;
+        // OK: Any has @:from method with Type Parameter T, all types are accepted
+        var myAbstractVar:MyAbstract =  anyVar;
+    }
+}
+
+
+abstract MyAbstract(Int) {
+    inline function new(i:Int) {
+        this = i;
+    }
+
+    @:from
+    static public function fromString(s:String) {
+        return new MyAbstract(Std.parseInt(s));
+    }
+
+    @:to
+    public function toArray() {
+        return [this];
+    }
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -166,6 +166,9 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
   public void testAbstractFromTo() throws Exception {
     doTestNoFixWithWarnings();
   }
+  public void testAbstractFromToMetadata() throws Exception {
+    doTestNoFixWithWarnings();
+  }
 
   public void testAbstractAssignmentFromTo1() throws Exception {
     doTestNoFixWithWarnings();


### PR DESCRIPTION
This should add support for Abstract implicit casts (`@:to` / `@:from` methods)
I removed the old code for solving `Map` assignability as it is no longer needed.

How it is suppose to work  is described n the link below, i  didn't place the logic inside `getCompatibleTypesInternal` as i needed to call `canAssignToFrom` while also avoiding a  stack overflow  when 2 types can cast to each other. (see the bottom of the page)

https://haxe.org/manual/types-abstract-implicit-casts.html

![image](https://user-images.githubusercontent.com/3193925/96186062-2ac56a00-0f3b-11eb-8aef-b398c10f1348.png)


