### PR TITLE
Allow the usage of final keyword in interfaces

### DIFF
--- a/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -229,6 +229,7 @@ haxe.semantic.static.field.override=Field ''{0}'' overrides a static field of a 
 haxe.semantic.variable.redefinition=Redefinition of variable ''{0}'' in subclass is not allowed. Previously declared at ''{1}''.
 haxe.semantic.property.cant.be.final=Property can not be final
 haxe.semantic.final.static.var.init=Static final variable ''{0}'' must be initialized
+haxe.semantic.final.static.var.init.interface=Default values on interfaces are not allowed
 haxe.semantic.statement.does.not.unify.with.asserted.type=Statement of type ''{0}'' does not unify with asserted type ''{1}.''
 haxe.semantic.interface.error.message=Not an interface
 haxe.semantic.parameter.default.type.should.be.constant=Parameter default type should be constant but was {0}

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -455,7 +455,7 @@ class FieldChecker {
     if (field.isProperty()) {
       checkProperty(field, holder);
     } else {
-      if (FINAL_FIELD_IS_INITIALIZED.isEnabled(var)) {
+      if (FINAL_FIELD_IS_INITIALIZED.isEnabled(var) &&  !isParentInterface(var)) {
         if (field.isFinal() && !field.hasInitializer()) {
           if (field.isStatic()) {
             holder.createErrorAnnotation(var, HaxeBundle.message("haxe.semantic.final.static.var.init", field.getName()));
@@ -503,6 +503,10 @@ class FieldChecker {
         }
       }
     }
+  }
+
+  private static boolean isParentInterface(HaxeFieldDeclaration var) {
+    return var.getParent() instanceof HaxeInterfaceBody;
   }
 
   private static boolean isFieldInitializedInTheConstructor(HaxeFieldModel field) {

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -455,13 +455,20 @@ class FieldChecker {
     if (field.isProperty()) {
       checkProperty(field, holder);
     } else {
-      if (FINAL_FIELD_IS_INITIALIZED.isEnabled(var) &&  !isParentInterface(var)) {
-        if (field.isFinal() && !field.hasInitializer()) {
-          if (field.isStatic()) {
-            holder.createErrorAnnotation(var, HaxeBundle.message("haxe.semantic.final.static.var.init", field.getName()));
-          }
-          else if (!isFieldInitializedInTheConstructor(field)) {
-            holder.createErrorAnnotation(var, HaxeBundle.message("haxe.semantic.final.var.init", field.getName()));
+      if (FINAL_FIELD_IS_INITIALIZED.isEnabled(var)) {
+        if (field.isFinal()) {
+          if (!field.hasInitializer()) {
+            if (!isParentInterface(var)) {
+              if (field.isStatic()) {
+                holder.createErrorAnnotation(var, HaxeBundle.message("haxe.semantic.final.static.var.init", field.getName()));
+              } else if (!isFieldInitializedInTheConstructor(field)) {
+                holder.createErrorAnnotation(var, HaxeBundle.message("haxe.semantic.final.var.init", field.getName()));
+              }
+            }
+          } else {
+            if (isParentInterface(var)) {
+              holder.createErrorAnnotation(var, HaxeBundle.message("haxe.semantic.final.static.var.init.interface", field.getName()));
+            }
           }
         }
       }

--- a/testData/annotation.semantic/FinalKeywordInInterface.hx
+++ b/testData/annotation.semantic/FinalKeywordInInterface.hx
@@ -10,5 +10,6 @@ class FinalInInterface implements TestInterface {
 
 interface TestInterface {
     final field:Int;
+    <error descr="Default values on interfaces are not allowed">final fieldWrong:Int = 1;</error>
     final function test():Void;
 }

--- a/testData/annotation.semantic/FinalKeywordInInterface.hx
+++ b/testData/annotation.semantic/FinalKeywordInInterface.hx
@@ -1,0 +1,14 @@
+package;
+
+class FinalInInterface implements TestInterface {
+
+    public final field:Int = 1;
+    public function test() {}
+    public function new() {}
+
+}
+
+interface TestInterface {
+    final field:Int;
+    final function test():Void;
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -271,6 +271,10 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
+  public void testFinalKeywordInInterface() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
   public void testStaticsInExtended() throws Exception {
     doTestNoFixWithoutWarnings();
   }


### PR DESCRIPTION
This one should fix https://github.com/HaxeFoundation/intellij-haxe/issues/1028 (No need to check if final variable is assigned in interfaces)