### PR TITLE
Feature/map literal fix

### DIFF
--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
@@ -339,8 +339,9 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
 
   private List<SpecificHaxeClassReference> emptyCollectionAssignment(Compatibility direction) {
     if (direction == Compatibility.ASSIGNABLE_TO && context instanceof HaxeArrayLiteral && null == ((HaxeArrayLiteral)context).getExpressionList()) {
-      ResultHolder unknownHolder = SpecificTypeReference.getUnknown(context).createHolder();
-      SpecificHaxeClassReference holder = (SpecificHaxeClassReference)SpecificHaxeClassReference.createMap(unknownHolder, unknownHolder);
+      ResultHolder unknownHolderKey = SpecificTypeReference.getUnknown(context).createHolder();
+      ResultHolder unknownHolderValue = SpecificTypeReference.getDynamic(context).createHolder();
+      SpecificHaxeClassReference holder = (SpecificHaxeClassReference)SpecificHaxeClassReference.createMap(unknownHolderKey, unknownHolderValue);
       return Collections.singletonList(holder);
     }
     return Collections.emptyList();

--- a/testData/annotation.semantic/AssignEmptyCollection.hx
+++ b/testData/annotation.semantic/AssignEmptyCollection.hx
@@ -3,4 +3,5 @@ package;
 class <info descr="null">EmptyCollections</info> {
     public var <info descr="null">emptyArray</info>:<info descr="null">Array</info><<info descr="null">String</info>> = [] ;
     public var <info descr="null">emptyMap</info>:<info descr="null">Map</info><<info descr="null">String</info>, <info descr="null">String</info>> = [] ;
+    public var <info descr="null">emptyMap2</info>:<info descr="null">Map</info><<info descr="null">String</info>, <info descr="null">Int</info>> = [] ;
 }


### PR DESCRIPTION
This should fix the issue with assigning empty collections `[]`to maps with different specifics. ( https://github.com/HaxeFoundation/intellij-haxe/issues/980 )

The problem was that since both the key and value specifics shared the same object reference for an empty collection a change to the key (ex. replacing unknown with String) would also affect the  value specific and change that one as well.

so a  `Map<String, Int> = []`  would not work  because the literal `[]` would be converted from `Map<Unknown, unknown>` to Map`<String, String>` when the key Specific got updated to contain a String type in HaxeTypeCompatible#canAssignToFrom.

HaxeTypeCompatible.java
```
  static public boolean canAssignToFrom(@Nullable ResultHolder to, @Nullable ResultHolder from) {
    if (null == to || null == from) return false;
    if (to.isUnknown()) {
      to.setType(from.getType().withoutConstantValue());
    }
    else if (from.isUnknown()) {
      from.setType(to.getType().withoutConstantValue()); // <--- since both map specifics are the same object this will update both.
    }
    return canAssignToFrom(to.getType(), from.getType(), true, from.isInitExpression());
  }
```