### PR TITLE
Fix Incompatible Type w/ Generic Functions

### DIFF
--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -93,6 +93,7 @@
         <li>Checks field and property implementations when implementing interfaces</li>
         <li>Improved method implementation checks for interfaces</li>
         <li>Recognize implicit cast methods in Abstracts (Methods annotated with @:to / @From)</li>
+        <li>Fix type incompatiblity warning when assigning parameterized (generic) function result type.</li>
         <li>Fix a few cases where empty square brackets were not recognized for initializing Maps. (Issue #980)</li>
         <li>Updated which classes are auto-imported.</li>
         <li>Follow usings as if they were imports when resolving identifiers.</li>

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
@@ -130,7 +130,9 @@ public class HaxeMethodModel extends HaxeMemberModel implements HaxeExposableMod
     return out;
   }
 
+  @Deprecated // Delete ASAP
   public SpecificFunctionReference getFunctionType() {
+    // WARNING: If your calling function is failing dealing with type parameters, then you need to call the version that takes a resolver.
     return getFunctionType(null);
   }
 

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
@@ -400,7 +400,7 @@ public class HaxeExpressionEvaluator {
           if (reference != null) {
             PsiElement subelement = reference.resolve();
             if (subelement instanceof HaxeMethod) {
-              functionType = ((HaxeMethod)subelement).getModel().getFunctionType();
+              functionType = ((HaxeMethod)subelement).getModel().getFunctionType(resolver);
             }
           }
         }
@@ -605,7 +605,7 @@ public class HaxeExpressionEvaluator {
       final HaxeMethodModel method = HaxeJavaUtil.cast(HaxeBaseMemberModel.fromPsi(element), HaxeMethodModel.class);
       final HaxeMethodModel parentMethod = (method != null) ? method.getParentMethod(resolver) : null;
       if (parentMethod != null) {
-        return parentMethod.getFunctionType().createHolder();
+        return parentMethod.getFunctionType(resolver).createHolder();
       }
       context.addError(element, "Calling super without parent constructor");
       return SpecificHaxeClassReference.getUnknown(element).createHolder();

--- a/testData/annotation.semantic/InitializeObjectWithGenericFunction.hx
+++ b/testData/annotation.semantic/InitializeObjectWithGenericFunction.hx
@@ -1,0 +1,20 @@
+package;
+
+class DisplayObject {
+  public function new() {}
+}
+
+class Sprite extends DisplayObject {
+  public function new() { super(); }
+}
+
+class Test {
+  public static function type<T>(o:Any, t:Class<T>):T {
+    return (Std.is(o,t) ? o : null);
+  }
+
+  public static function main() {
+    var sprite:Sprite = new Sprite();
+    var dObj:DisplayObject = type(sprite, DisplayObject); // Incompatible Type (T should be DisplayObject)
+  }
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -619,7 +619,9 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
-
+  public void testInitializeObjectWithGenericFunction() throws Exception {
+    doTestNoFixWithWarnings();
+  }
 
   public void testIsKeywordFor4_2() throws Throwable {
     HashSet skipAnnotators = new HashSet();


### PR DESCRIPTION
Fix type incompatibility warning when assigning parameterized (generic) function result type.