### PR TITLE
Adding EnumValue members to Enum types

### DIFF
--- a/src/common/com/intellij/plugins/haxe/model/HaxeEnumModelImpl.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeEnumModelImpl.java
@@ -18,6 +18,7 @@ package com.intellij.plugins.haxe.model;
 
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
+import com.intellij.plugins.haxe.util.HaxeEnumValueUtil;
 import com.intellij.util.SmartList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -124,12 +125,25 @@ public class HaxeEnumModelImpl extends HaxeClassModel implements HaxeEnumModel {
 
   @Override
   public HaxeMemberModel getMember(@NotNull final String name, @Nullable HaxeGenericResolver resolver) {
-    return getValue(name);
+    HaxeMemberModel value = getValue(name);
+    if (!isAbstract() && value == null) value = getEnumValueMember(name, resolver);
+    return  value;
+  }
+
+  @Nullable
+  private HaxeMemberModel getEnumValueMember(String name, HaxeGenericResolver resolver) {
+    HaxeClassModel model = HaxeEnumValueUtil.getEnumValueClassModel(this.getPsi());
+    if(model == null) return null;
+    return model.getMember(name, resolver);
   }
 
   @Override
   public List<HaxeMemberModel> getMembers(@Nullable HaxeGenericResolver resolver) {
-    return getValuesStream().collect(Collectors.toList());
+    List<HaxeMemberModel> members = getValuesStream().collect(Collectors.toList());
+    if (!isAbstract()) {
+      members.addAll(HaxeEnumValueUtil.getEnumValueClassMembers(this.getPsi(), resolver));
+    }
+    return members;
   }
 
   @NotNull

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
@@ -402,7 +402,7 @@ public abstract class SpecificTypeReference {
   }
 
   @Nullable
-  private static HaxeClassModel getStdTypeModel(String name, PsiElement context) {
+  public static HaxeClassModel getStdTypeModel(String name, PsiElement context) {
     return HaxeProjectModel.fromElement(context).getStdPackage().getClassModel(name);
   }
 

--- a/src/common/com/intellij/plugins/haxe/util/HaxeEnumValueUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeEnumValueUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2020 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.util;
+
+import com.intellij.plugins.haxe.model.HaxeClassModel;
+import com.intellij.plugins.haxe.model.HaxeMemberModel;
+import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
+import com.intellij.plugins.haxe.model.type.ResultHolder;
+import com.intellij.plugins.haxe.model.type.SpecificHaxeClassReference;
+import com.intellij.psi.PsiElement;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static com.intellij.plugins.haxe.model.type.SpecificTypeReference.getStdClass;
+import static com.intellij.plugins.haxe.model.type.SpecificTypeReference.getStdTypeModel;
+
+/**
+ * Util to easily get EnumValueClass reference and model
+ */
+public class HaxeEnumValueUtil {
+
+  //TODO can any of these  results be cached ?
+
+  @NotNull
+  public static SpecificHaxeClassReference getEnumValueClass(@NotNull PsiElement context) {
+    return getStdClass("EnumValue", context, new ResultHolder[]{});
+  }
+
+  @Nullable
+  public static HaxeClassModel getEnumValueClassModel(@NotNull PsiElement context) {
+    return getStdTypeModel("EnumValue", context);
+  }
+  public static List<HaxeMemberModel> getEnumValueClassMembers(@NotNull PsiElement context, @Nullable HaxeGenericResolver resolver) {
+    HaxeClassModel enumValueModel = getStdTypeModel("EnumValue", context);
+    if(enumValueModel == null) return new LinkedList<>();
+    return  enumValueModel.getMembers(resolver);
+  }
+}

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -321,6 +321,10 @@ public class HaxeResolveUtil {
       baseTypes.addAll(haxeClass.getHaxeExtendsList());
       baseTypes.addAll(haxeClass.getHaxeImplementsList());
       List<HaxeClass> baseClasses = tyrResolveClassesByQName(baseTypes);
+      if (haxeClass.isEnum() && !haxeClass.isAbstract() && haxeClass.getContext() != null) {
+        //Enums should provide the same methods as EnumValue
+        baseClasses.add(HaxeEnumValueUtil.getEnumValueClass(haxeClass.getContext()).getHaxeClass());
+      }
       for (HaxeClass baseClass : baseClasses) {
         if (processed.add(baseClass)) {
           classes.add(baseClass);

--- a/testData/annotation.semantic/EnumHasEnumValueMembers.hx
+++ b/testData/annotation.semantic/EnumHasEnumValueMembers.hx
@@ -1,0 +1,15 @@
+package ;
+enum MyEnum { Foo; Bar; }
+class Demo {
+    public static function main()
+    {
+        var foo = MyEnum.Foo;
+        var bar:MyEnum = Bar;
+
+        // `match` is not resolved:
+        MyEnum.Foo.match(MyEnum.Foo);
+        Foo.match(MyEnum.Foo);
+        foo.match(MyEnum.Bar);
+        bar.match(Foo);
+    }
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -632,5 +632,8 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
   public void testIsKeywordFor4_1() throws Throwable {
     doTestSkippingAnnotators(new HashSet<>());
   }
+  public void testEnumHasEnumValueMembers() throws Throwable {
+    doTestSkippingAnnotators(new HashSet<>());
+  }
 
 }


### PR DESCRIPTION
This adds  EnumValue members to Enum classes (its  currently only `match(pattern:Dynamic):Bool `)
I am not sure if abstracts annotated with  @:Enum should have this feature, so i exclude  those for now.

 this should solve issue https://github.com/HaxeFoundation/intellij-haxe/issues/106 