### PR TITLE
Fixing issue where implicit cast checks failed when type was used tro…

### DIFF
--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
@@ -188,13 +188,15 @@ public class HaxeTypeCompatible {
     if (canAssignToFromSpecificType(to, from)) return true;
 
     Set<SpecificHaxeClassReference> compatibleTypes = to.getCompatibleTypes(SpecificHaxeClassReference.Compatibility.ASSIGNABLE_FROM);
-    if (to.isAbstract() && transitive) compatibleTypes.addAll(to.getHaxeClassModel().getImplicitCastTypesList(to));
+    SpecificHaxeClassReference resolvedTo = to.isTypeDef() ? to.resolveTypeDef() : to;
+    if (resolvedTo.isAbstract() && transitive) compatibleTypes.addAll(resolvedTo.getHaxeClassModel().getImplicitCastTypesList(to));
     for (SpecificHaxeClassReference compatibleType : compatibleTypes) {
       if (canAssignToFromSpecificType(compatibleType, from, initExpression)) return true;
     }
 
     compatibleTypes = from.getCompatibleTypes(SpecificHaxeClassReference.Compatibility.ASSIGNABLE_TO);
-    if (from.isAbstract() && transitive) compatibleTypes.addAll(from.getHaxeClassModel().getCastableToTypesList(from));
+    SpecificHaxeClassReference resolvedFrom = from.isTypeDef() ? from.resolveTypeDef() : from;
+    if (resolvedFrom.isAbstract() && transitive) compatibleTypes.addAll(resolvedFrom.getHaxeClassModel().getCastableToTypesList(from));
     for (SpecificHaxeClassReference compatibleType : compatibleTypes) {
       if (canAssignToFromSpecificType(to, compatibleType, initExpression)) return true;
     }

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
@@ -380,6 +380,14 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
     return clazz instanceof HaxeTypedefDeclaration;
   }
 
+  public SpecificHaxeClassReference resolveTypeDef() {
+    if(isTypeDef()) {
+      SpecificHaxeClassReference type = ((AbstractHaxeTypeDefImpl)getHaxeClassModel().haxeClass).getTargetClass(getGenericResolver());
+      if (type != null) return type;
+    }
+    return this;
+  }
+
   public boolean isCoreType() {
     HaxeMetadataList list = HaxeMetadataUtils.getMetadataList(this.getHaxeClass());
     return list.stream().anyMatch(meta -> meta.isCompileTimeMeta() &&  meta.isType("coreType"));

--- a/testData/annotation.semantic/ImplicitCast.hx
+++ b/testData/annotation.semantic/ImplicitCast.hx
@@ -1,0 +1,38 @@
+package ;
+typedef MyAbstractAsTypeDef = MyAbstract;
+class ImplicitCast {
+    public function new() {
+    }
+    public function test() {
+        var assignFrom:MyAbstract = "3" ; // OK; got @:from Metadata on method to convert
+        var assignTo:Array<Int> = assignFrom ;  // OK; got @:to Metadata on method to convert
+
+        var anyVar:Any = assignFrom ; //  OK: Any extends dynamic and has a @:to  with Type Parameter T
+        var myAbstractVar:MyAbstract =  anyVar; // OK: Any extends dynamic and has a @:from with Type Parameter T
+
+        var typeDefVar:MyAbstractAsTypeDef = "2"; //OK,  typeDef resolves to abstract with implicit cast
+
+        var <error descr="Incompatible type: Int should be MyAbstract">wrongUse1:MyAbstract = 1</error>;  // WRONG: while an abstract of int it is not the same as an int.
+        var <error descr="Incompatible type: MyAbstract should be Int">wrongUse2:Int = assignFrom</error>; //WRONG  while this is an abstract of in we do not have a converter method.
+        var <error descr="Incompatible type: Int should be MyAbstractAsTypeDef">wrongUse3:MyAbstractAsTypeDef = 2</error>; //WRONG, typeDef resolves to abstract that does not have a @:from method for int
+
+    }
+}
+
+
+abstract MyAbstract(Int) {
+    inline function new(i:Int) {
+        this = i;
+    }
+    @:from
+    static public function fromString(s:String) {
+        return new MyAbstract(Std.parseInt(s));
+    }
+
+    @:to
+    public function toArray() {
+        return [this];
+    }
+}
+
+

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -619,6 +619,10 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
+  public void testImplicitCast() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
   public void testInitializeObjectWithGenericFunction() throws Exception {
     doTestNoFixWithWarnings();
   }


### PR DESCRIPTION
This should fix a small issue with implicit casts where the assignable check would fail if the type to check was provided trough a typeDef.

The problem  in short:
Implicit casts are only allowed for Abstacts,  the original code would only check if the input was an abstract  which typeDefs are not,  i am therefore adding a few lines to resolve  any typeDef to their underlying type before checking if its an abstract.