### PR TITLE
Feature/optional var syntax

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -343,13 +343,17 @@ private enum_value_declaration_recovery ::= !(ID | '}' | 'class' | 'enum' | 'abs
 
 private enumConstructorParameters ::= parenthesizedParameterList
 
-fieldDeclaration ::= fieldModifier* mutabilityModifier componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
+optionalToken ::= '?'
+private RequiredFieldDeclaration ::= fieldModifier* mutabilityModifier componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
-optionalFieldDeclaration ::= fieldModifier* mutabilityModifier '?' componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
-{pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
+private optionalFieldDeclaration ::= fieldModifier* mutabilityModifier optionalToken componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
+{pin=4 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
+
+fieldDeclaration ::=  (RequiredFieldDeclaration | optionalFieldDeclaration)
+{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
 
 localVarDeclarationList ::= mutabilityModifier localVarDeclaration (',' localVarDeclaration)* <<semicolonUnlessPrecededByStatement>>{pin=2}
-localVarDeclaration ::= componentName typeTag? varInit?
+localVarDeclaration ::= '?'?componentName typeTag? varInit?
   {recoverWhile="local_var_declaration_part_recover" mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
 private localVarDeclarationWithInit ::= componentName typeTag? varInit {extends=localVarDeclaration}
 private local_var_declaration_part_recover ::= !('!' | ppToken | '(' | ')' | '++' | ',' | '-' | '--' | ';' | '[' | 'break' | 'case' | 'cast' | 'continue' | 'default' | 'do' | 'else' | 'false' | 'final' | 'for' | 'function' | 'if' | 'new' | 'null' | 'return' | 'super' | 'switch' | 'this' | 'throw' | 'true' | 'try' | 'untyped' | 'var' | 'while' | '{' | '}' | '~' | ID | OPEN_QUOTE | LITFLOAT | LITHEX | LITINT | LITOCT | REG_EXP)

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -343,17 +343,13 @@ private enum_value_declaration_recovery ::= !(ID | '}' | 'class' | 'enum' | 'abs
 
 private enumConstructorParameters ::= parenthesizedParameterList
 
-optionalToken ::= '?'
-private RequiredFieldDeclaration ::= fieldModifier* mutabilityModifier componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
+fieldDeclaration ::= fieldModifier* mutabilityModifier componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
-private optionalFieldDeclaration ::= fieldModifier* mutabilityModifier optionalToken componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
-{pin=4 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
-
-fieldDeclaration ::=  (RequiredFieldDeclaration | optionalFieldDeclaration)
-{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
+optionalFieldDeclaration ::= fieldModifier* mutabilityModifier '?' componentName propertyDeclaration? typeTag? varInit? <<semicolonUnlessPrecededByStatement>>
+{pin=3 extends=fieldDeclaration mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
 
 localVarDeclarationList ::= mutabilityModifier localVarDeclaration (',' localVarDeclaration)* <<semicolonUnlessPrecededByStatement>>{pin=2}
-localVarDeclaration ::= '?'?componentName typeTag? varInit?
+localVarDeclaration ::= componentName typeTag? varInit?
   {recoverWhile="local_var_declaration_part_recover" mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxePsiField"}
 private localVarDeclarationWithInit ::= componentName typeTag? varInit {extends=localVarDeclaration}
 private local_var_declaration_part_recover ::= !('!' | ppToken | '(' | ')' | '++' | ',' | '-' | '--' | ';' | '[' | 'break' | 'case' | 'cast' | 'continue' | 'default' | 'do' | 'else' | 'false' | 'final' | 'for' | 'function' | 'if' | 'new' | 'null' | 'return' | 'super' | 'switch' | 'this' | 'throw' | 'true' | 'try' | 'untyped' | 'var' | 'while' | '{' | '}' | '~' | ID | OPEN_QUOTE | LITFLOAT | LITHEX | LITINT | LITOCT | REG_EXP)
@@ -750,7 +746,7 @@ private anonymousTypeWithEmptyBody ::= '{' '}' {pin=2}
 private regularAnonymousTypeBody ::= '{' anonymousTypeBodyContents '}' {pin=2}
 private anonymousTypeBodyContents ::= extendedAnonymousTypeBody | simpleAnonymousTypeBody | anonymousInterfaceBodyList
 private extendedAnonymousTypeBody ::= typeExtendsList (',' anonymousTypeFieldList)? (sep anonymousInterfaceBodyList)?
-private anonymousInterfaceBodyList ::= (interfaceBodyPart | optionalFieldDeclaration)+  {recoverWhile="interface_body_part_recover"}
+private anonymousInterfaceBodyList ::= (optionalFieldDeclaration | interfaceBodyPart )+  {recoverWhile="interface_body_part_recover"}
 private simpleAnonymousTypeBody ::= anonymousTypeFieldList (sep anonymousInterfaceBodyList)?
 typeExtendsList ::= '>' type (',' '>' type)* {pin=1}
 

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
@@ -104,8 +104,7 @@ public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implem
   }
 
   public boolean isOptional() {
-    final HaxeOptionalToken optionalToken = PsiTreeUtil.getChildOfType(this, HaxeOptionalToken.class);
-    return optionalToken != null;
+    return this instanceof  HaxeOptionalFieldDeclaration;
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
@@ -103,6 +103,11 @@ public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implem
     return compName != null ? PsiTreeUtil.getChildOfType(compName, HaxeIdentifier.class) : null;
   }
 
+  public boolean isOptional() {
+    final HaxeOptionalToken optionalToken = PsiTreeUtil.getChildOfType(this, HaxeOptionalToken.class);
+    return optionalToken != null;
+  }
+
   @Nullable
   @Override
   public PsiDocComment getDocComment() {

--- a/testData/annotation.semantic/OptionalFieldSyntax.hx
+++ b/testData/annotation.semantic/OptionalFieldSyntax.hx
@@ -1,0 +1,17 @@
+  typedef Haxe3Format =
+  {
+     @:optional var name:String;
+     @:optional var surname:String;
+  };
+
+  typedef Haxe4Format =
+  {
+     var ?name:String;
+     var ?surname:String;
+  };
+
+class OptionalFieldsSyntax {
+ public function new(?optionalArgument:String) {
+    <error descr="<statement> expected, got 'var'">var</error> ?optionalLocalVarNotAllowed:String;
+ }
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -143,6 +143,10 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
+  public void testOptionalFieldSyntax() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
   public void testOptionalWithInitWarning() throws Exception {
     doTestNoFixWithWarnings();
   }


### PR DESCRIPTION
Fixing issue https://github.com/HaxeFoundation/intellij-haxe/issues/950  by tweaking `haxe.bnf `

my current understanding of the problem:
The anonymous structure was matched with `interfaceBodyPart`  before  testing `optionalFieldDeclaration` and  since interfaces does not allow optional fields but has normal fields with pinning the optional fields were never matched.

It looks like its working as  expected with these tweaks :
![image](https://user-images.githubusercontent.com/3193925/98471577-95da2780-21ed-11eb-9bf0-6ce3f1f7b86c.png)
