### PR TITLE
Prevents clean and rebuild tasks from accidentally deleting project or work dir.

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/projectStructure/ui/HaxeConfigurationEditor.java
@@ -489,7 +489,9 @@ public class HaxeConfigurationEditor {
     final String url = myExtension.getCompilerOutputUrl();
     final String urlCandidate = VfsUtil.pathToUrl(myFolderTextField.getText());
 
-    if (!urlCandidate.equals(url)) {
+    // IMPORTANT!: do not save if only "file://"
+    // The virtual file system can resolve this (usually to workDir) and can cause a lot of damage when  a clean task is executed.
+    if (!urlCandidate.equals(url) && !urlCandidate.equalsIgnoreCase("file://")) {
       myExtension.setCompilerOutputPath(urlCandidate);
       myExtension.commit();
     }


### PR DESCRIPTION
I think i have found the bug that have caused accidental deletion of  project directory or home directory.

in `HaxeConfigurationEditor`  we use ` VfsUtil.pathToUrl` to convert user input into something the Virtual file system can read. if you send  in an empty string or a value that can not be converted to a path it seems to always return  `file://`  and this will resolve the the work directory for IntelliJ. since we didn't do any validation  on `urlCandidate` we would set Compiler Output Path to `file://` and any clean or rebuild task would then delete whatever directory file:// would resolve to.

With the chances from this branch the user would get a error message telling them that that the directory is not set, instead of accidentally deleting some other folder.
![image](https://user-images.githubusercontent.com/3193925/102693368-708ffe80-421a-11eb-8edf-f7c9789b4117.png)


NOTE: this does not solve this problems for existing projects that might have the output directory already set to `file://`


