### PR TITLE
Improving parsing (missing semi-colons wont cause unparsable block-statement)

### DIFF
--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -537,7 +537,7 @@ throwStatement ::= 'throw' expression ';'?
 
 // TODO: Allow multiple, comma delimited, expressions on switch statement.
 switchStatement ::= 'switch' expression switchBlock
-switchBlock ::= '{' (switchCase | defaultCase)* '}'
+switchBlock ::= '{' (switchCase | defaultCase)* '}'{pin=1}
 switchCaseBlock ::= (literalExpression <<semicolonUnlessPrecededByStatement>>) | statementList
 switchCase ::= 'case' switchCaseExpr (',' switchCaseExpr)* guard? ':' switchCaseBlock? {pin=1 recoverWhile="switch_case_recover"}
 switchCaseExpr ::= (switchExtractorExpression  | expression | switchCaseCaptureVar) {pin=1} // Should NOT be named Expression, because it should not be an expression.

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -477,7 +477,8 @@ typeOrAnonymous ::= type | anonymousType
 
 // The predicate !(objectLiteralElementList) is required to keep blockStatement from competing for precedence. Also need to override the statement pin value.
 blockStatement ::= '{' !objectLiteralElementList statementList? '}' {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeBlockStatementPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeBlockStatementPsiMixin" extends="com.intellij.plugins.haxe.lang.psi.HaxeBlockStatementPsiMixin"}
-private statementList ::= (statement (<<semicolonUnlessPrecededByStatement>> statement)* ';'?) {recoverWhile="statement_recovery"}
+private statementWithOptionalSemicolon ::= statement <<semicolonUnlessPrecededByStatement>> statementWithOptionalSemicolon? {pin=1}
+private statementList ::= (statementWithOptionalSemicolon ';'?) {recoverWhile="statement_recovery"}
 private statement_recovery ::= !('case' | 'default' | '}')
 
 private statement ::= blockStatement | notBlockStatement

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -85,6 +85,7 @@
   <![CDATA[
       <p>Unreleased changes</p>
       <ul>
+        <li>improved block-statement parsing and added quickfix for missing semicolon</li>
         <li>Add support for import.hx</li>
         <li>Recognize and use static extensions having unifiable (assignable) types. (Issue #964)</li>
         <li>Add support for 'is' keyword.</li>

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -1115,6 +1115,8 @@
     <importFilteringRule implementation="com.intellij.plugins.haxe.ide.HaxeImportFilteringRule"/>
     <targetElementEvaluator language="Haxe" implementationClass="com.intellij.plugins.haxe.ide.HaxeTargetElementEvaluator"/>
 
+    <errorQuickFixProvider implementation="com.intellij.plugins.haxe.ide.annotator.MissingSemicolonQuickFixProvider"/>
+
     <annotator language="Haxe" implementationClass="com.intellij.plugins.haxe.ide.annotator.HaxeColorAnnotator"/>
     <annotator language="Haxe" implementationClass="com.intellij.plugins.haxe.ide.annotator.HaxeTypeAnnotator"/>
     <annotator language="Haxe" implementationClass="com.intellij.plugins.haxe.ide.annotator.HaxeSemanticAnnotator"/>

--- a/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
+++ b/src/common/com/intellij/plugins/haxe/HaxeBundle.properties
@@ -273,6 +273,7 @@ haxe.quickfix.wrap.assignment.with.parenthesis=Wrap assignment with parenthesis
 haxe.quickfix.wrap.is.expression.with.parenthesis=Wrap "is" expression with parenthesis
 haxe.quickfix.wrap.expression.with.parenthesis=Wrap expression with parenthesis.
 haxe.quickfix.wrap.left.hand.side.with.parenthesis=Wrap left-hand side with parenthesis.
+haxe.quickfix.missing.semi.colon=Add missing semicolon.
 
 # HAXE parameter info helper
 haxe.parameter.info.helper.no.parameters=No parameters

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/MissingSemicolonQuickFixProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/MissingSemicolonQuickFixProvider.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2020 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.ide.annotator;
+
+import com.intellij.codeInsight.daemon.impl.HighlightInfo;
+import com.intellij.codeInsight.daemon.impl.analysis.ErrorQuickFixProvider;
+import com.intellij.plugins.haxe.HaxeBundle;
+import com.intellij.plugins.haxe.model.fixer.HaxeMissingSemicolonFixer;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiErrorElement;
+import org.jetbrains.annotations.NotNull;
+
+public class MissingSemicolonQuickFixProvider implements ErrorQuickFixProvider {
+  private static final String MISSING_SEMICOLON = HaxeBundle.message("parsing.error.missing.semi.colon");
+
+  @Override
+  public void registerErrorQuickFix(@NotNull PsiErrorElement errorElement, @NotNull HighlightInfo highlightInfo) {
+    if (MISSING_SEMICOLON.equals(errorElement.getErrorDescription())) {
+
+      HaxeMissingSemicolonFixer action = addMissingSemicolon(errorElement);
+      highlightInfo.registerFix(action, null, "Add semicolon", errorElement.getTextRange(), null);
+    }
+  }
+
+  @NotNull
+  private static HaxeMissingSemicolonFixer addMissingSemicolon(@NotNull PsiElement expr) {
+    return new HaxeMissingSemicolonFixer(expr);
+  }
+}

--- a/src/common/com/intellij/plugins/haxe/model/fixer/HaxeMissingSemicolonFixer.java
+++ b/src/common/com/intellij/plugins/haxe/model/fixer/HaxeMissingSemicolonFixer.java
@@ -17,20 +17,45 @@
  */
 package com.intellij.plugins.haxe.model.fixer;
 
+import com.intellij.codeInspection.util.IntentionName;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.HaxeBundle;
+import com.intellij.plugins.haxe.ide.quickfix.HaxeFixAndIntentionAction;
 import com.intellij.plugins.haxe.model.HaxeDocumentModel;
 import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiFile;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-public class HaxeMissingSemicolonFixer extends HaxeFixer {
-  private PsiElement element;
+public class HaxeMissingSemicolonFixer extends HaxeFixAndIntentionAction {
 
-  public HaxeMissingSemicolonFixer(PsiElement element) {
-    super(HaxeBundle.message("haxe.quickfix.missing.semi.colon"));
-    this.element = element;
+
+  public HaxeMissingSemicolonFixer(@Nullable PsiElement element) {
+    super(element);
+  }
+
+  @Nls
+  @NotNull
+  @Override
+  public String getFamilyName() {
+    return HaxeBundle.message("haxe.quickfix.missing.semi.colon");
   }
 
   @Override
-  public void run() {
-    HaxeDocumentModel.fromElement(element).addTextAfterElement(element, ";");
+  public void invoke(@NotNull Project project,
+                     @NotNull PsiFile file,
+                     @Nullable Editor editor,
+                     @NotNull PsiElement startElement,
+                     @NotNull PsiElement endElement) {
+
+    HaxeDocumentModel.fromElement(startElement).addTextAfterElement(startElement, ";");
+  }
+
+  @NotNull
+  @Override
+  public @IntentionName String getText() {
+    return HaxeBundle.message("haxe.quickfix.missing.semi.colon");
   }
 }

--- a/src/common/com/intellij/plugins/haxe/model/fixer/HaxeMissingSemicolonFixer.java
+++ b/src/common/com/intellij/plugins/haxe/model/fixer/HaxeMissingSemicolonFixer.java
@@ -17,7 +17,6 @@
  */
 package com.intellij.plugins.haxe.model.fixer;
 
-import com.intellij.codeInspection.util.IntentionName;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.HaxeBundle;
@@ -55,7 +54,7 @@ public class HaxeMissingSemicolonFixer extends HaxeFixAndIntentionAction {
 
   @NotNull
   @Override
-  public @IntentionName String getText() {
+  public String getText() {
     return HaxeBundle.message("haxe.quickfix.missing.semi.colon");
   }
 }

--- a/src/common/com/intellij/plugins/haxe/model/fixer/HaxeMissingSemicolonFixer.java
+++ b/src/common/com/intellij/plugins/haxe/model/fixer/HaxeMissingSemicolonFixer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2000-2013 JetBrains s.r.o.
+ * Copyright 2014-2020 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.model.fixer;
+
+import com.intellij.plugins.haxe.HaxeBundle;
+import com.intellij.plugins.haxe.model.HaxeDocumentModel;
+import com.intellij.psi.PsiElement;
+
+public class HaxeMissingSemicolonFixer extends HaxeFixer {
+  private PsiElement element;
+
+  public HaxeMissingSemicolonFixer(PsiElement element) {
+    super(HaxeBundle.message("haxe.quickfix.missing.semi.colon"));
+    this.element = element;
+  }
+
+  @Override
+  public void run() {
+    HaxeDocumentModel.fromElement(element).addTextAfterElement(element, ";");
+  }
+}

--- a/testData/annotation.semantic/ArrayAssignmentBadFunctionType.hx
+++ b/testData/annotation.semantic/ArrayAssignmentBadFunctionType.hx
@@ -1,7 +1,7 @@
 package;
 class Test {
-  <error descr="Incompatible type: Array<Int->String> should be Array<Int->Int>">var should_warn1: Array<Int->Int> = [ (x:Int)->{'$x'} ];</error>
+  <error descr="Incompatible type: Array<Int->String> should be Array<Int->Int>">var should_warn1: Array<Int->Int> = [ (x:Int)->{'$x';} ];</error>
   public function new() {
-    var <error descr="Incompatible type: Array<Int->String> should be Array<Int->Int>">should_warn1: Array<Int->Int> = [ (x:Int)->{'$x'} ]</error>;
+    var <error descr="Incompatible type: Array<Int->String> should be Array<Int->Int>">should_warn1: Array<Int->Int> = [ (x:Int)->{'$x';} ]</error>;
   }
 }

--- a/testData/annotation.semantic/IsKeywordFor4_1.hx
+++ b/testData/annotation.semantic/IsKeywordFor4_1.hx
@@ -97,9 +97,9 @@ class IsOperator extends Base {
         var incorrectUse6 <error descr="Unparenthesized ''is'' expression cannot be used for variable initialization. (pre-4.2 semantics)">= myString</error> is <error descr="Unsupported type for ''is'' operator.">{var x:Int; var y:Int;}</error>  // 'Unsupported type for `is` operator.'
         var incorrectUse7 <error descr="Unparenthesized ''is'' expression cannot be used for variable initialization. (pre-4.2 semantics)">= myString</error> is <error descr="Unsupported type for ''is'' operator.">{function iterator(){}}</error>  // 'Unsupported type for `is` operator.'
 
-        if (true) {"Some" + "thing";} else {"Nothing";} is <error descr="'!', '%', '&&', '(', '->', '.', '...', ';', <<, <operation>, <operator>, '?', '[', is or '||' expected, got 'String'">String</error>; // 4.2: characters 60-66 : Missing ;
-        try { var s; s = "else"; } catch (e) {} is String; // 4.2: characters 52-58 : Missing ;
-        switch (ary[0]) { case _ => c: c; } is String; // 4.2:  characters 48-54 : Missing ;
+        if (true) {"Some" + "thing";} else {"Nothing";} is<error descr="Missing semicolon."> </error>String; // 4.2: characters 60-66 : Missing ;
+        try { var s; s = "else"; } catch (e) {} is<error descr="Missing semicolon."> </error>String; // 4.2: characters 52-58 : Missing ;
+        switch (ary[0]) { case _ => c: c; } is<error descr="Missing semicolon."> </error>String; // 4.2:  characters 48-54 : Missing ;
 
         switch myString { case _ is String: trace(true); }
         // super is String; // Parses, but cannot use super as value.

--- a/testData/annotation.semantic/IsKeywordFor4_2.hx
+++ b/testData/annotation.semantic/IsKeywordFor4_2.hx
@@ -97,9 +97,9 @@ class IsOperator extends Base {
         var incorrectUse6 = myString is <error descr="Unsupported type for ''is'' operator.">{var x:Int; var y:Int;}</error>  // 'Unsupported type for `is` operator.'
         var incorrectUse7 = myString is <error descr="Unsupported type for ''is'' operator.">{function iterator(){}}</error>  // 'Unsupported type for `is` operator.'
 
-        if (true) {"Some" + "thing";} else {"Nothing";} is <error descr="'!', '%', '&&', '(', '->', '.', '...', ';', <<, <operation>, <operator>, '?', '[', is or '||' expected, got 'String'">String</error>; // 4.2: characters 60-66 : Missing ;
-        try { var s; s = "else"; } catch (e) {} is String; // 4.2: characters 52-58 : Missing ;
-        switch (ary[0]) { case _ => c: c; } is String; // 4.2:  characters 48-54 : Missing ;
+        if (true) {"Some" + "thing";} else {"Nothing";} is<error descr="Missing semicolon."> </error>String; // 4.2: characters 60-66 : Missing ;
+        try { var s; s = "else"; } catch (e) {} is<error descr="Missing semicolon."> </error>String; // 4.2: characters 52-58 : Missing ;
+        switch (ary[0]) { case _ => c: c; } is<error descr="Missing semicolon."> </error>String; // 4.2:  characters 48-54 : Missing ;
 
         switch myString { case _ is String: trace(true); }
         // super is String; // Parses, but cannot use super as value.

--- a/testData/annotation/IDEA_106515_2.hx
+++ b/testData/annotation/IDEA_106515_2.hx
@@ -1,5 +1,5 @@
 class <info descr="null">Test</info> {
   public static function <info descr="null">main</info>() {
-    <error descr="Unresolved type">TArray</error>
+    <error descr="Unresolved type">TArray</error>;
   }
 }


### PR DESCRIPTION
changing how statementLists are pares so that missing semi-colons wont mark an entire block-statement as unparsable.

before:
![image](https://user-images.githubusercontent.com/3193925/103027625-81ac7880-4556-11eb-9420-3d335b14dec4.png)
After:
![image](https://user-images.githubusercontent.com/3193925/103027676-95f07580-4556-11eb-89b3-403f5fff3e6d.png)

Some tests where missing `;` so i added where needed.