### PR TITLE
Allow optional arguments when assigning to type that require it

### DIFF
--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
@@ -133,7 +133,7 @@ public class HaxeTypeCompatible {
         return false;
       }
       for (int n = 0; n < toArgSize; n++) {
-        if (!to.arguments.get(n).canAssign(from.arguments.get(n))) return false;
+        if (!to.arguments.get(n).canAssignToFrom(from.arguments.get(n))) return false;
       }
     }
     // Void return on the to just means that the value isn't used/cared about. See

--- a/testData/annotation.semantic/OptionalMethodSyntax.hx
+++ b/testData/annotation.semantic/OptionalMethodSyntax.hx
@@ -1,0 +1,30 @@
+
+class OptionalFieldsSyntax {
+ public function new(?optionalArgument:String) {
+    var callbackWithRequired:String->Void;
+    var callbackWithOptional:?String->Void;
+
+    callbackWithRequired = optionalMarkArg;
+    callbackWithRequired = optionalArg;
+    callbackWithRequired = reqArg;
+    // wrong argument type
+    callbackWithRequired = <error descr="Incompatible type: ?Int->Void should be String->Void">optionalOtherArg</error>;
+    callbackWithRequired = <error descr="Incompatible type: Int->Void should be String->Void">otherArg</error>;
+
+    callbackWithOptional = optionalMarkArg;
+    callbackWithOptional = optionalArg;
+
+    //Optional parameters can't be forced
+    callbackWithOptional = <error descr="Incompatible type: String->Void should be ?String->Void">reqArg</error>;
+    // wrong argument type
+    callbackWithOptional = <error descr="Incompatible type: ?Int->Void should be ?String->Void">optionalOtherArg</error>;
+    callbackWithOptional = <error descr="Incompatible type: Int->Void should be ?String->Void">otherArg</error>;
+
+ }
+
+  public function optionalMarkArg(?arg:String):Void {}
+  public function optionalArg(arg:String = null):Void {}
+  public function optionalOtherArg(?arg:Int):Void {}
+  public function reqArg(arg:String):Void {}
+  public function otherArg(arg:Int):Void {}
+}

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -147,6 +147,10 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
+  public void testOptionalMethodSyntax() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
   public void testOptionalWithInitWarning() throws Exception {
     doTestNoFixWithWarnings();
   }


### PR DESCRIPTION
Haxe allow you to assign methods with optional parameters to types that has the same parameters but required.
ex.

```haxe
function optionalArg(?str:String):Void {}
var callback:String->Void = optionalArg;
```
this PR fixes this, and it also contains a change in how function parameters are read so we get the correct value when checking if parameter is optional.