### PR TITLE
Github actions for making releases and pre-releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   Build:
     strategy:
-      fail-fast: false # set this to true if oyu want to cancel all builds if one fails.
+      fail-fast: false # set this to true if you want to cancel all builds if one fails.
       matrix:
         IDEA_VERSION: [2020.2, 2020.1.4,2019.3.5,2018.3.6]
         OS: [macOS-latest, ubuntu-latest, windows-latest]

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -16,20 +16,26 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
       id: ${{ steps.create_release.outputs.id }}
     steps:
-    - name: Get short SHA
-      id: short_sha
-      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+      - name: Get Time
+        id: timestep
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: 'YYYYMMDDHHmm'
 
-    - name: Create Pre-release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: pre-release/${{ steps.short_sha.outputs.sha8 }}
-        release_name: Beta build (${{ steps.short_sha.outputs.sha8 }})
-        draft: true
-        prerelease: true
+      - name: Get short SHA
+        id: short_sha
+        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+
+      - name: Create Pre-release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: pre-release/${{steps.timestep.outputs.time }}
+          release_name: Beta build (${{ steps.short_sha.outputs.sha8 }})
+          draft: true
+          prerelease: true
 
   build:
     name: Build and upload artifacts
@@ -105,10 +111,10 @@ jobs:
     needs: [prepare, build]
     runs-on: ubuntu-latest
     steps:
-    - name: Publish release
-      uses: StuYarrow/publish-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        id: ${{ needs.prepare.outputs.id }}
+      - name: Publish release
+        uses: StuYarrow/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          id: ${{ needs.prepare.outputs.id }}
 

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,114 @@
+name: Pre-release, IntelliJ-Haxe-plugin
+
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+
+
+jobs:
+  prepare:
+    name: Create Pre-release draft
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      id: ${{ steps.create_release.outputs.id }}
+    steps:
+    - name: Get short SHA
+      id: short_sha
+      run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+
+    - name: Create Pre-release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: pre-release/${{ steps.short_sha.outputs.sha8 }}
+        release_name: Beta build (${{ steps.short_sha.outputs.sha8 }})
+        draft: true
+        prerelease: true
+
+  build:
+    name: Build and upload artifacts
+    strategy:
+      fail-fast: true # cancel all builds if one fails.
+      matrix:
+        IDEA_VERSION: [2020.2, 2020.1.4,2019.3.5,2018.3.6]
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          architecture: x64
+
+      - name: Set up Haxe
+        uses: krdlab/setup-haxe@v1
+        with:
+          haxe-version: 4.1.3
+
+      - name: Test haxe
+        run: haxe -version
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Cache plugin downloads
+        uses: actions/cache@v2
+        with:
+          path: $GITHUB_WORKSPACE/dependencies
+          key: ${{ matrix.IDEA_VERSION }}-downloads-${{ hashFiles('downloads/**') }}
+          restore-keys: ${{ matrix.IDEA_VERSION }}-downloads
+
+      - name: Cache intelliJ downloads
+        uses: actions/cache@v2
+        with:
+          path: $GITHUB_WORKSPACE/idea-IU
+          key: ${{ matrix.IDEA_VERSION }}-idea-${{ hashFiles('ideaIU-${{ matrix.IDEA_VERSION }}/**') }}
+          restore-keys: ${{ matrix.IDEA_VERSION }}-idea
+
+      - name: Build with Gradle
+        run: gradle clean build  verifyPlugin -PtargetVersion="${{ matrix.IDEA_VERSION }}" -x test
+
+
+      - name: Find assets
+        id: find_assets
+        run: |
+          ARTIFACT_PATHNAME=$(ls *.jar | head -n 1)
+          ARTIFACT_NAME=$(basename $ARTIFACT_PATHNAME)
+          echo ::set-output name=artifact_name::${ARTIFACT_NAME}
+          echo ::set-output name=artifact_pathname::${ARTIFACT_PATHNAME}
+
+
+      - name: Upload Asset
+        id: upload-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.prepare.outputs.upload_url }}
+          asset_path: ${{ steps.find_assets.outputs.artifact_pathname }}
+          asset_name: intellij-haxe-${{ matrix.IDEA_VERSION }}-beta.jar
+          asset_content_type: application/java-archive
+
+  finish:
+    name: publish Pre-release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Publish release
+      uses: StuYarrow/publish-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        id: ${{ needs.prepare.outputs.id }}
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,128 @@
+name: Release, IntelliJ-Haxe-plugin
+
+
+on:
+  push:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+**" # trigger on  tags that matches version numbers ex. 1.3.10
+
+
+
+jobs:
+  prepare:
+    name: Create release draft
+    runs-on: ubuntu-latest
+    outputs:
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+      id: ${{ steps.create_release.outputs.id }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: shorten Changelog
+        id: shortlog
+        run: |
+          sed -b -e '/^\r\?$/,$d' CHANGELOG.md >> shortlog.txt
+
+      - name: read Changelog
+        id: changelog
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./shortlog.txt
+
+      - name: Get short SHA
+        id: short_sha
+        run: echo "::set-output name=sha8::$(echo ${GITHUB_SHA} | cut -c1-8)"
+
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
+          body: ${{ steps.changelog.outputs.content }}
+          draft: true
+          prerelease: false
+
+  build:
+    name: Build and upload artifacts
+    strategy:
+      fail-fast: true # cancel all builds if one fails.
+      matrix:
+        IDEA_VERSION: [2020.2, 2020.1.4,2019.3.5,2018.3.6]
+    needs: prepare
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          architecture: x64
+
+      - name: Set up Haxe
+        uses: krdlab/setup-haxe@v1
+        with:
+          haxe-version: 4.1.3
+
+      - name: Test haxe
+        run: haxe -version
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Cache plugin downloads
+        uses: actions/cache@v2
+        with:
+          path: $GITHUB_WORKSPACE/dependencies
+          key: ${{ matrix.IDEA_VERSION }}-downloads-${{ hashFiles('downloads/**') }}
+          restore-keys: ${{ matrix.IDEA_VERSION }}-downloads
+
+      - name: Cache intelliJ downloads
+        uses: actions/cache@v2
+        with:
+          path: $GITHUB_WORKSPACE/idea-IU
+          key: ${{ matrix.IDEA_VERSION }}-idea-${{ hashFiles('ideaIU-${{ matrix.IDEA_VERSION }}/**') }}
+          restore-keys: ${{ matrix.IDEA_VERSION }}-idea
+
+      - name: Build with Gradle
+        run: gradle clean build  verifyPlugin -PtargetVersion="${{ matrix.IDEA_VERSION }}" -x test
+
+
+      - name: Find assets
+        id: find_assets
+        run: |
+          ARTIFACT_PATHNAME=$(ls *.jar | head -n 1)
+          ARTIFACT_NAME=$(basename $ARTIFACT_PATHNAME)
+          echo ::set-output name=artifact_name::${ARTIFACT_NAME}
+          echo ::set-output name=artifact_pathname::${ARTIFACT_PATHNAME}
+
+
+      - name: Upload Asset
+        id: upload-asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.prepare.outputs.upload_url }}
+          asset_path: ${{ steps.find_assets.outputs.artifact_pathname }}
+          asset_name: intellij-haxe-${{ matrix.IDEA_VERSION }}.jar
+          asset_content_type: application/java-archive
+
+
+  finish:
+    name: publish release
+    needs: [prepare, build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish release
+        uses: StuYarrow/publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          id: ${{ needs.prepare.outputs.id }}
+


### PR DESCRIPTION
Github actions for automatic creation of releases and uploading of artifacts.
- creates pre-releases when committing to develop/master  (kinda like nightly builds) 
- creates releases when commit is tagged with version number on the format of `[0-9]+.[0-9]+.[0-9]+.*` (ex.`1.4.0-hotfix1`)
 The release logic will pull text from `CHANGELOG.md` and  add everything from the top until it finds an empty line.
(all releases can be modified and or deleted afterwards if they contain errors)

if a pre-release for every commit to master/develop is too often i can tune it to nightly or weekly (monthly?)  or manually if that is preferred.

Example of a release created by Github actions.
![image](https://user-images.githubusercontent.com/3193925/103485151-a0332f00-4df4-11eb-98d3-92bd2c5172ca.png)
Example of a pre-release created by Github actions. (when release body is empty it will show commits instead)
![image](https://user-images.githubusercontent.com/3193925/103485639-15543380-4df8-11eb-9998-45326dd1a9d5.png)


