### PR TITLE
Fixing parsing of types containing a mixture of old and new function types 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,7 +7,10 @@ on:
       - 'develop'
       - 'feature/*'
     pull_request:
-          types: [opened, synchronize, reopened]
+      branches:
+        - 'master'
+        - 'develop'
+        - 'feature/*'
 
 jobs:
   Build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,11 +6,11 @@ on:
       - 'master'
       - 'develop'
       - 'feature/*'
-    pull_request:
-      branches:
-        - 'master'
-        - 'develop'
-        - 'feature/*'
+  pull_request:
+    branches:
+      - 'master'
+      - 'develop'
+      - 'feature/*'
 
 jobs:
   Build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,6 +6,8 @@ on:
       - 'master'
       - 'develop'
       - 'feature/*'
+    pull_request:
+          types: [opened, synchronize, reopened]
 
 jobs:
   Build:

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -229,6 +229,15 @@ private prefixOperator ::= '-' | '!' | '~'    { extends=operator }
 private questionOperator ::= '?'              { extends=operator }
 private suffixOperator ::= '!'                { extends=operator }
 
+// KFROM and KTO are only keywords for abstracts and can be used as identifiers elsewhere in the code
+identifier ::= ID | KFROM | KTO
+{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeIdentifierPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeIdentifierPsiMixin" name="identifier"}
+
+thisExpression ::= 'this'
+{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeReference"}
+
+superExpression ::= 'super'
+{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeReference"}
 
 packageStatement ::= 'package' simpleQualifiedReferenceExpression? ';'
 {pin=1 implements="com.intellij.plugins.haxe.lang.psi.HaxePackageStatementPsiMixin" mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxePackageStatementPsiMixinImpl"}
@@ -305,11 +314,13 @@ externInterfaceDeclaration ::= externAndMaybePrivate? 'interface' componentName 
 classDeclaration ::= classModifierList? 'class' componentName genericParam? inheritList? classBody
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass" implements="com.intellij.plugins.haxe.lang.psi.HaxeClass"}
 
-//'from' | 'to'
-underlyingType ::= '(' typeWrapper ')'
-abstractClassDeclaration ::= privateKeyWord? abstractClassType componentName genericParam? underlyingType? ((identifier) ('(' typeWrapper ')' | typeWrapper))* abstractBody
+
+abstractClassDeclaration ::= privateKeyWord? abstractClassType componentName genericParam? underlyingType? (abstractToType | abstractFromType)* abstractBody
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass" implements="com.intellij.plugins.haxe.lang.psi.HaxeClass"}
 abstractClassType ::= 'enum'? 'abstract'
+underlyingType ::= '(' typeWrapper ')'
+abstractToType ::= 'to' ('(' typeWrapper ')' | typeWrapper){pin=1}
+abstractFromType ::= 'from' ('(' typeWrapper ')' | typeWrapper){pin=1}
 abstractBody ::= '{' abstractBodyPart* '}' {extends="classBody"}
 private abstractBodyPart ::= fieldDeclaration | methodDeclaration | constructorDeclaration {recoverWhile="class_body_part_recover"}
 
@@ -713,14 +724,6 @@ private simpleQualifiedReferenceExpression ::= referenceExpression qualifiedRefe
 
 componentName ::= identifier
 {mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeNamedElementImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeNamedElement"}
-identifier ::= ID
-{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeIdentifierPsiMixinImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeIdentifierPsiMixin" name="identifier"}
-
-thisExpression ::= 'this'
-{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeReference"}
-
-superExpression ::= 'super'
-{mixin="com.intellij.plugins.haxe.lang.psi.impl.HaxeReferenceImpl" implements="com.intellij.plugins.haxe.lang.psi.HaxeReference"}
 
 // XXX - This could be callExpression, and it makes sense that newExpression would extend/implement callExpression,
 //       but that affects a lot of code and is best not attempted just before a release...

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -307,7 +307,7 @@ classDeclaration ::= classModifierList? 'class' componentName genericParam? inhe
 
 //'from' | 'to'
 underlyingType ::= '(' typeWrapper ')'
-abstractClassDeclaration ::= privateKeyWord? abstractClassType componentName genericParam? underlyingType? ((identifier) type)* abstractBody
+abstractClassDeclaration ::= privateKeyWord? abstractClassType componentName genericParam? underlyingType? ((identifier) ('(' typeWrapper ')' | typeWrapper))* abstractBody
 {pin=3 mixin="com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass" implements="com.intellij.plugins.haxe.lang.psi.HaxeClass"}
 abstractClassType ::= 'enum'? 'abstract'
 abstractBody ::= '{' abstractBodyPart* '}' {extends="classBody"}
@@ -436,7 +436,7 @@ private namedTypeOrAnonymous ::= [optionalMark] [componentName ':'] typeOrAnonym
 private namedFunctionType ::= [optionalMark] [componentName ':'] functionType
 private optionalFunctionTypeWithoutName ::= optionalMark '(' functionType ')' {pin=3}
 
-private oldFunctionType ::= oldFunctionTypeArgumentsList functionReturnType {pin=2}
+private oldFunctionType ::= oldFunctionTypeArgumentsList (functionReturnType |'(' functionReturnType ')') {pin=2}
 private oldFunctionTypeArgumentsList ::= ( oldFunctionTypeArgument '->')+
 oldFunctionTypeArgument ::= optionalMark? ('(' functionType ')' | typeOrAnonymous) {elementType="functionArgument" pin(".*")=3}
 

--- a/grammar/haxe.bnf
+++ b/grammar/haxe.bnf
@@ -436,7 +436,7 @@ private namedTypeOrAnonymous ::= [optionalMark] [componentName ':'] typeOrAnonym
 private namedFunctionType ::= [optionalMark] [componentName ':'] functionType
 private optionalFunctionTypeWithoutName ::= optionalMark '(' functionType ')' {pin=3}
 
-private oldFunctionType ::= oldFunctionTypeArgumentsList (functionReturnType |'(' functionReturnType ')') {pin=2}
+private oldFunctionType ::= oldFunctionTypeArgumentsList ('(' functionReturnType ')' | functionReturnType) {pin=2}
 private oldFunctionTypeArgumentsList ::= ( oldFunctionTypeArgument '->')+
 oldFunctionTypeArgument ::= optionalMark? ('(' functionType ')' | typeOrAnonymous) {elementType="functionArgument" pin(".*")=3}
 

--- a/grammar/haxe.flex
+++ b/grammar/haxe.flex
@@ -297,8 +297,8 @@ CONDITIONAL_ERROR="#error"[^\r\n]*
 "cast"                                    { return emitToken( KCAST);  }
 
 "abstract"                                {  return emitToken( KABSTRACT);  }
-//"from"                                    {  return emitToken( KFROM);  }
-//"to"                                      {  return emitToken( KTO );  }
+"from"                                    {  return emitToken( KFROM);  }
+"to"                                      {  return emitToken( KTO );  }
 
 "class"                                   {  return emitToken( KCLASS);  }
 "enum"                                    {  return emitToken( KENUM);  }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -202,9 +202,9 @@ public class HaxeClassModel implements HaxeExposableModel {
     List<HaxeType> types = new LinkedList<HaxeType>();
     HaxeAbstractClassDeclaration abstractClass = (HaxeAbstractClassDeclaration)haxeClass;
     List<HaxeAbstractToType> list = abstractClass.getAbstractToTypeList();
-    for(HaxeAbstractToType fromType : list) {
-      if(fromType.getTypeOrAnonymous() != null ) {
-        types.add(fromType.getTypeOrAnonymous().getType());
+    for(HaxeAbstractToType toType : list) {
+      if(toType.getTypeOrAnonymous() != null ) {
+        types.add(toType.getTypeOrAnonymous().getType());
       }
     }
     return types;

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -203,8 +203,9 @@ public class HaxeClassModel implements HaxeExposableModel {
     for (HaxeIdentifier id : UsefulPsiTreeUtil.getChildren(haxeClass, HaxeIdentifier.class)) {
       if (id.getText().equals("to")) {
         PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingSkipWhiteSpacesAndComments(id);
-        if (sibling instanceof HaxeType) {
-          types.add((HaxeType)sibling);
+        if (sibling instanceof HaxeTypeOrAnonymous) {
+          HaxeTypeOrAnonymous typeOrAnonymous = (HaxeTypeOrAnonymous) sibling;
+          types.add(typeOrAnonymous.getType());
         }
       }
     }
@@ -302,8 +303,9 @@ public class HaxeClassModel implements HaxeExposableModel {
     for (HaxeIdentifier id : UsefulPsiTreeUtil.getChildren(haxeClass, HaxeIdentifier.class)) {
       if (id.getText().equals("from")) {
         PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingSkipWhiteSpacesAndComments(id);
-        if (sibling instanceof HaxeType) {
-          types.add((HaxeType)sibling);
+        if (sibling instanceof HaxeTypeOrAnonymous) {
+          HaxeTypeOrAnonymous typeOrAnonymous = (HaxeTypeOrAnonymous) sibling;
+          types.add(typeOrAnonymous.getType());
         }
       }
     }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -196,17 +196,15 @@ public class HaxeClassModel implements HaxeExposableModel {
     return null;
   }
 
-  // @TODO: this should be properly parsed in haxe.bnf so searching for to is not required
   public List<HaxeType> getAbstractToList() {
-    if (!isAbstract()) return Collections.emptyList();
+    if (!isAbstract() ) return Collections.emptyList();
+
     List<HaxeType> types = new LinkedList<HaxeType>();
-    for (HaxeIdentifier id : UsefulPsiTreeUtil.getChildren(haxeClass, HaxeIdentifier.class)) {
-      if (id.getText().equals("to")) {
-        PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingSkipWhiteSpacesAndComments(id);
-        if (sibling instanceof HaxeTypeOrAnonymous) {
-          HaxeTypeOrAnonymous typeOrAnonymous = (HaxeTypeOrAnonymous) sibling;
-          types.add(typeOrAnonymous.getType());
-        }
+    HaxeAbstractClassDeclaration abstractClass = (HaxeAbstractClassDeclaration)haxeClass;
+    List<HaxeAbstractToType> list = abstractClass.getAbstractToTypeList();
+    for(HaxeAbstractToType fromType : list) {
+      if(fromType.getTypeOrAnonymous() != null ) {
+        types.add(fromType.getTypeOrAnonymous().getType());
       }
     }
     return types;
@@ -296,17 +294,14 @@ public class HaxeClassModel implements HaxeExposableModel {
 
 
 
-  // @TODO: this should be properly parsed in haxe.bnf so searching for from is not required
   public List<HaxeType> getAbstractFromList() {
-    if (!isAbstract()) return Collections.emptyList();
+    if (!isAbstract() ) return Collections.emptyList();
     List<HaxeType> types = new LinkedList<HaxeType>();
-    for (HaxeIdentifier id : UsefulPsiTreeUtil.getChildren(haxeClass, HaxeIdentifier.class)) {
-      if (id.getText().equals("from")) {
-        PsiElement sibling = UsefulPsiTreeUtil.getNextSiblingSkipWhiteSpacesAndComments(id);
-        if (sibling instanceof HaxeTypeOrAnonymous) {
-          HaxeTypeOrAnonymous typeOrAnonymous = (HaxeTypeOrAnonymous) sibling;
-          types.add(typeOrAnonymous.getType());
-        }
+    HaxeAbstractClassDeclaration abstractClass = (HaxeAbstractClassDeclaration)haxeClass;
+    List<HaxeAbstractFromType> list = abstractClass.getAbstractFromTypeList();
+    for(HaxeAbstractFromType fromType : list) {
+      if(fromType.getTypeOrAnonymous() != null ) {
+        types.add(fromType.getTypeOrAnonymous().getType());
       }
     }
     return types;

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
@@ -98,14 +98,14 @@ public class HaxeTypeCompatible {
 
     // if abstract of function is being compared to a function we map the abstract to its underlying function
     if (hasAbstractFunctionTypeCast(to, true) && isFunctionTypeOrReference(from)) {
-      List<SpecificFunctionReference> functionTypes = getAbstractFunctionTypes(to, true);
+      List<SpecificFunctionReference> functionTypes = getAbstractFunctionTypes((SpecificHaxeClassReference)to, true);
       SpecificFunctionReference fromFunctionType = asFunctionReference(from);
       for(SpecificFunctionReference functionType  : functionTypes) {
         if(canAssignToFromFunction(functionType, fromFunctionType)) return true;
       }
     }
     if (isFunctionTypeOrReference(to) && hasAbstractFunctionTypeCast(from, false)) {
-      List<SpecificFunctionReference> functionTypes = getAbstractFunctionTypes(from, false);
+      List<SpecificFunctionReference> functionTypes = getAbstractFunctionTypes((SpecificHaxeClassReference)from, false);
       SpecificFunctionReference toFunctionType = asFunctionReference(to);
       for(SpecificFunctionReference functionType  : functionTypes) {
         if(canAssignToFromFunction(toFunctionType, functionType)) return true;
@@ -171,8 +171,7 @@ public class HaxeTypeCompatible {
     return false;
   }
 
-  private static List<SpecificFunctionReference> getAbstractFunctionTypes(SpecificTypeReference reference, boolean getCastFrom) {
-    SpecificHaxeClassReference classReference = (SpecificHaxeClassReference)reference;
+  private static List<SpecificFunctionReference> getAbstractFunctionTypes(SpecificHaxeClassReference classReference, boolean getCastFrom) {
     HaxeAbstractClassDeclaration abstractClass = (HaxeAbstractClassDeclaration)classReference.getHaxeClass();
     List<SpecificFunctionReference> list = new ArrayList<>();
     if (abstractClass != null) {

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeTypeCompatible.java
@@ -171,7 +171,9 @@ public class HaxeTypeCompatible {
     return false;
   }
 
+  @NotNull
   private static List<SpecificFunctionReference> getAbstractFunctionTypes(SpecificHaxeClassReference classReference, boolean getCastFrom) {
+    if (!(classReference.getHaxeClass() instanceof HaxeAbstractClassDeclaration))  return Collections.emptyList();
     HaxeAbstractClassDeclaration abstractClass = (HaxeAbstractClassDeclaration)classReference.getHaxeClass();
     List<SpecificFunctionReference> list = new ArrayList<>();
     if (abstractClass != null) {

--- a/testData/annotation.semantic/AbstractAssignmentFromToFunctions.hx
+++ b/testData/annotation.semantic/AbstractAssignmentFromToFunctions.hx
@@ -1,0 +1,35 @@
+package;
+
+class AbstractAssignmentFromTo1 {
+  public static function variableTests():Void {
+    var val:FunctionFromTo =  function(i:Int){return;};
+    var val:FunctionFrom =  function(i:Int){return;};
+
+    var val:FunctionFromTo =  testMethodIV;
+    var val:FunctionFrom =  testMethodIV;
+
+    // should fail due to wrong parameter types
+    var <error descr="Incompatible type: String->Int should be FunctionFromTo">val:FunctionFromTo =  function(i:String){return 1;}</error>;
+    var <error descr="Incompatible type: String->Int should be FunctionFrom">val:FunctionFrom =  function(i:String){return 1;}</error>;
+    var <error descr="Incompatible type: String->Void should be FunctionFromTo">val:FunctionFromTo =  testMethodSV</error>;
+
+    //should fail (has no from type or implisit casts)
+    var <error descr="Incompatible type: Int->Void should be FunctionTo">val:FunctionTo =  function(i:Int){return;}</error>;
+    var <error descr="Incompatible type: Int->Void should be FunctionTo">val:FunctionTo =  testMethodIV</error>;
+    var <error descr="Incompatible type: Int->Void should be FunctionNon">val:FunctionNon =  testMethodIV</error>;
+
+  }
+
+  public static function testMethodIV(i:Int) {return;}
+  public static function testMethodSV(i:String) {return;}
+}
+
+
+
+abstract FunctionFromTo(Int->Void) from Int->Void to Int->Void {}
+
+abstract FunctionFrom(Int->Void) from Int->Void {}
+
+abstract FunctionTo(Int->Void) to Int->Void {}
+
+abstract FunctionNon(Int->Void) {}

--- a/testData/parsing/haxe/declarations/import/Empty182.txt
+++ b/testData/parsing/haxe/declarations/import/Empty182.txt
@@ -1,5 +1,5 @@
 Haxe File
   IMPORT_STATEMENT
     HaxePsiToken:import('import')
-    PsiErrorElement:ID expected
+    PsiErrorElement:<expression> expected
       <empty list>

--- a/testData/parsing/haxe/expressions/Haxe3.txt
+++ b/testData/parsing/haxe/expressions/Haxe3.txt
@@ -1143,10 +1143,11 @@ Haxe File
         HaxePsiToken:ID('Kilometer')
     IDENTIFIER
       HaxePsiToken:ID('from')
-    TYPE
-      REFERENCE_EXPRESSION
-        IDENTIFIER
-          HaxePsiToken:ID('Int')
+    TYPE_OR_ANONYMOUS
+      TYPE
+        REFERENCE_EXPRESSION
+          IDENTIFIER
+            HaxePsiToken:ID('Int')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       METHOD_DECLARATION
@@ -1242,10 +1243,11 @@ Haxe File
         HaxePsiToken:ID('Int')
     IDENTIFIER
       HaxePsiToken:ID('to')
-    TYPE
-      REFERENCE_EXPRESSION
-        IDENTIFIER
-          HaxePsiToken:ID('Float')
+    TYPE_OR_ANONYMOUS
+      TYPE
+        REFERENCE_EXPRESSION
+          IDENTIFIER
+            HaxePsiToken:ID('Float')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       HaxePsiToken:}('}')
@@ -1258,16 +1260,18 @@ Haxe File
         HaxePsiToken:ID('UInt')
     IDENTIFIER
       HaxePsiToken:ID('to')
-    TYPE
-      REFERENCE_EXPRESSION
-        IDENTIFIER
-          HaxePsiToken:ID('Int')
+    TYPE_OR_ANONYMOUS
+      TYPE
+        REFERENCE_EXPRESSION
+          IDENTIFIER
+            HaxePsiToken:ID('Int')
     IDENTIFIER
       HaxePsiToken:ID('from')
-    TYPE
-      REFERENCE_EXPRESSION
-        IDENTIFIER
-          HaxePsiToken:ID('Int')
+    TYPE_OR_ANONYMOUS
+      TYPE
+        REFERENCE_EXPRESSION
+          IDENTIFIER
+            HaxePsiToken:ID('Int')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       HaxePsiToken:}('}')
@@ -1480,16 +1484,18 @@ Haxe File
       HaxePsiToken:)(')')
     IDENTIFIER
       HaxePsiToken:ID('from')
-    TYPE
-      REFERENCE_EXPRESSION
-        IDENTIFIER
-          HaxePsiToken:ID('Int')
+    TYPE_OR_ANONYMOUS
+      TYPE
+        REFERENCE_EXPRESSION
+          IDENTIFIER
+            HaxePsiToken:ID('Int')
     IDENTIFIER
       HaxePsiToken:ID('to')
-    TYPE
-      REFERENCE_EXPRESSION
-        IDENTIFIER
-          HaxePsiToken:ID('Int')
+    TYPE_OR_ANONYMOUS
+      TYPE
+        REFERENCE_EXPRESSION
+          IDENTIFIER
+            HaxePsiToken:ID('Int')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       PsiComment(MSL_COMMENT)('// MyInt + MyInt can be used as is, and returns a MyInt')

--- a/testData/parsing/haxe/expressions/Haxe3.txt
+++ b/testData/parsing/haxe/expressions/Haxe3.txt
@@ -1141,13 +1141,13 @@ Haxe File
     COMPONENT_NAME
       IDENTIFIER
         HaxePsiToken:ID('Kilometer')
-    IDENTIFIER
-      HaxePsiToken:ID('from')
-    TYPE_OR_ANONYMOUS
-      TYPE
-        REFERENCE_EXPRESSION
-          IDENTIFIER
-            HaxePsiToken:ID('Int')
+    ABSTRACT_FROM_TYPE
+      HaxePsiToken:KFROM('from')
+      TYPE_OR_ANONYMOUS
+        TYPE
+          REFERENCE_EXPRESSION
+            IDENTIFIER
+              HaxePsiToken:ID('Int')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       METHOD_DECLARATION
@@ -1241,13 +1241,13 @@ Haxe File
     COMPONENT_NAME
       IDENTIFIER
         HaxePsiToken:ID('Int')
-    IDENTIFIER
-      HaxePsiToken:ID('to')
-    TYPE_OR_ANONYMOUS
-      TYPE
-        REFERENCE_EXPRESSION
-          IDENTIFIER
-            HaxePsiToken:ID('Float')
+    ABSTRACT_TO_TYPE
+      HaxePsiToken:KTO('to')
+      TYPE_OR_ANONYMOUS
+        TYPE
+          REFERENCE_EXPRESSION
+            IDENTIFIER
+              HaxePsiToken:ID('Float')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       HaxePsiToken:}('}')
@@ -1258,20 +1258,20 @@ Haxe File
     COMPONENT_NAME
       IDENTIFIER
         HaxePsiToken:ID('UInt')
-    IDENTIFIER
-      HaxePsiToken:ID('to')
-    TYPE_OR_ANONYMOUS
-      TYPE
-        REFERENCE_EXPRESSION
-          IDENTIFIER
-            HaxePsiToken:ID('Int')
-    IDENTIFIER
-      HaxePsiToken:ID('from')
-    TYPE_OR_ANONYMOUS
-      TYPE
-        REFERENCE_EXPRESSION
-          IDENTIFIER
-            HaxePsiToken:ID('Int')
+    ABSTRACT_TO_TYPE
+      HaxePsiToken:KTO('to')
+      TYPE_OR_ANONYMOUS
+        TYPE
+          REFERENCE_EXPRESSION
+            IDENTIFIER
+              HaxePsiToken:ID('Int')
+    ABSTRACT_FROM_TYPE
+      HaxePsiToken:KFROM('from')
+      TYPE_OR_ANONYMOUS
+        TYPE
+          REFERENCE_EXPRESSION
+            IDENTIFIER
+              HaxePsiToken:ID('Int')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       HaxePsiToken:}('}')
@@ -1482,20 +1482,20 @@ Haxe File
             IDENTIFIER
               HaxePsiToken:ID('Int')
       HaxePsiToken:)(')')
-    IDENTIFIER
-      HaxePsiToken:ID('from')
-    TYPE_OR_ANONYMOUS
-      TYPE
-        REFERENCE_EXPRESSION
-          IDENTIFIER
-            HaxePsiToken:ID('Int')
-    IDENTIFIER
-      HaxePsiToken:ID('to')
-    TYPE_OR_ANONYMOUS
-      TYPE
-        REFERENCE_EXPRESSION
-          IDENTIFIER
-            HaxePsiToken:ID('Int')
+    ABSTRACT_FROM_TYPE
+      HaxePsiToken:KFROM('from')
+      TYPE_OR_ANONYMOUS
+        TYPE
+          REFERENCE_EXPRESSION
+            IDENTIFIER
+              HaxePsiToken:ID('Int')
+    ABSTRACT_TO_TYPE
+      HaxePsiToken:KTO('to')
+      TYPE_OR_ANONYMOUS
+        TYPE
+          REFERENCE_EXPRESSION
+            IDENTIFIER
+              HaxePsiToken:ID('Int')
     ABSTRACT_BODY
       HaxePsiToken:{('{')
       PsiComment(MSL_COMMENT)('// MyInt + MyInt can be used as is, and returns a MyInt')

--- a/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/testSrc/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -210,6 +210,10 @@ public class HaxeSemanticAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
     doTestNoFixWithWarnings();
   }
 
+  public void testAbstractAssignmentFromToFunctions() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
   public void testNullFunction() throws Exception {
     doTestNoFixWithWarnings();
   }


### PR DESCRIPTION
This fixes some issues with parsing function types

```haxe
class TestTypes{
    public var test:Void -> Void; // works
    public var test1:(String)-> Void;  // works
    public var test2:(String-> Void) -> Void; // works
    public var test3:(String-> Void) -> (Void -> Void); // would fail before this fix
}

abstract Callback<T>(T->Void) from (T->Void) {} // would fail to parse before this fix 
```