### PR TITLE
Converting  streams to loops in heavy used areas and adding some null safety

### DIFF
--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
@@ -61,6 +61,8 @@ public abstract class AbstractHaxePsiClass extends AbstractHaxeNamedComponent im
 
   private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass");
 
+  private Boolean _isPrivate = null;
+
   static {
     LOG.info("Loaded AbstractHaxePsiClass");
     LOG.setLevel(Level.DEBUG);
@@ -500,21 +502,24 @@ public abstract class AbstractHaxePsiClass extends AbstractHaxeNamedComponent im
   }
 
   private boolean isPrivate() {
-    HaxePrivateKeyWord privateKeyWord = null;
-    if (this instanceof HaxeClassDeclaration) { // concrete class
-      privateKeyWord = getPrivateKeyWord(((HaxeClassDeclaration)this).getClassModifierList());
-    } else if (this instanceof HaxeAbstractClassDeclaration) { // abstract class
-      privateKeyWord = ((HaxeAbstractClassDeclaration)this).getPrivateKeyWord();
-    } else if (this instanceof HaxeExternClassDeclaration) { // extern class
-      privateKeyWord = getPrivateKeyWord(((HaxeExternClassDeclaration)this).getExternClassModifierList());
-    } else if (this instanceof HaxeTypedefDeclaration) { // typedef
-      privateKeyWord = ((HaxeTypedefDeclaration)this).getPrivateKeyWord();
-    } else if (this instanceof HaxeInterfaceDeclaration) { // interface
-      privateKeyWord = ((HaxeInterfaceDeclaration)this).getPrivateKeyWord();
-    } else if (this instanceof HaxeEnumDeclaration) { // enum
-      privateKeyWord = ((HaxeEnumDeclaration)this).getPrivateKeyWord();
+    if(_isPrivate == null) {
+      HaxePrivateKeyWord privateKeyWord = null;
+      if (this instanceof HaxeClassDeclaration) { // concrete class
+        privateKeyWord = getPrivateKeyWord(((HaxeClassDeclaration)this).getClassModifierList());
+      } else if (this instanceof HaxeAbstractClassDeclaration) { // abstract class
+        privateKeyWord = ((HaxeAbstractClassDeclaration)this).getPrivateKeyWord();
+      } else if (this instanceof HaxeExternClassDeclaration) { // extern class
+        privateKeyWord = getPrivateKeyWord(((HaxeExternClassDeclaration)this).getExternClassModifierList());
+      } else if (this instanceof HaxeTypedefDeclaration) { // typedef
+        privateKeyWord = ((HaxeTypedefDeclaration)this).getPrivateKeyWord();
+      } else if (this instanceof HaxeInterfaceDeclaration) { // interface
+        privateKeyWord = ((HaxeInterfaceDeclaration)this).getPrivateKeyWord();
+      } else if (this instanceof HaxeEnumDeclaration) { // enum
+        privateKeyWord = ((HaxeEnumDeclaration)this).getPrivateKeyWord();
+      }
+      _isPrivate =  (privateKeyWord != null);
     }
-    return (privateKeyWord != null);
+    return _isPrivate;
   }
 
   private HaxePrivateKeyWord getPrivateKeyWord(HaxeClassModifierList list) {

--- a/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeClassModel.java
@@ -39,7 +39,6 @@ import static com.intellij.plugins.haxe.HaxeComponentType.*;
 import static com.intellij.plugins.haxe.model.type.HaxeTypeCompatible.canAssignToFrom;
 import static com.intellij.plugins.haxe.util.HaxeGenericUtil.*;
 import static com.intellij.plugins.haxe.util.HaxeMetadataUtil.getMethodsWithMetadata;
-import static java.util.stream.Collectors.toList;
 
 public class HaxeClassModel implements HaxeExposableModel {
   public final HaxeClass haxeClass;
@@ -215,10 +214,14 @@ public class HaxeClassModel implements HaxeExposableModel {
     if (!isAbstract()) return Collections.emptyList();
     List<HaxeMethodModel> methodsWithMetadata = getCastToMethods();
 
-    return  methodsWithMetadata.stream()
-      .filter(methodModel -> castMethodAcceptsSource(sourceType, methodModel))
-      .map(m -> SetSpecificsConstraints(m, getReturnType(m)))
-      .collect(toList());
+    List<SpecificHaxeClassReference> list = new ArrayList<>();
+    for (HaxeMethodModel methodModel : methodsWithMetadata) {
+      if (castMethodAcceptsSource(sourceType, methodModel)) {
+        SpecificHaxeClassReference reference = setSpecificsConstraints(methodModel, getReturnType(methodModel));
+        list.add(reference);
+      }
+    }
+    return list;
   }
 
 
@@ -226,7 +229,7 @@ public class HaxeClassModel implements HaxeExposableModel {
     SpecificHaxeClassReference parameter = getTypeOfFirstParameter(methodModel);
     //implicit cast methods seems to accept both parameter-less methods and single parameter methods
     if (parameter == null) return true; // if no param then "this" is  the  input  and will always be compatible.
-    SpecificHaxeClassReference parameterWithRealRealSpecifics = SetSpecificsConstraints(methodModel, parameter);
+    SpecificHaxeClassReference parameterWithRealRealSpecifics = setSpecificsConstraints(methodModel, parameter);
 
     if(reference.isAbstract()) {
       SpecificHaxeClassReference underlying = reference.getHaxeClassModel().getUnderlyingClassReference(reference.getGenericResolver());
@@ -240,23 +243,29 @@ public class HaxeClassModel implements HaxeExposableModel {
     if (!isAbstract()) return Collections.emptyList();
     List<HaxeMethodModel> methodsWithMetadata = getCastFromMethods();
 
-    return methodsWithMetadata.stream()
-      // if return types can not be assign to target then skip this castMethod
-      .filter(m-> canAssignToFrom(targetType, SetSpecificsConstraints(m, getReturnType(m)), false))
-      .map(this::getImplicitCastFromType)// TODO consider applying generics from targetType to be more strict about what methods are supported ?
-      .filter(Objects::nonNull)
-      .collect(toList());
+    // if return types can not be assign to target then skip this castMethod
+    List<SpecificHaxeClassReference> list = new ArrayList<>();
+    for (HaxeMethodModel m : methodsWithMetadata) {
+      // TODO consider applying generics from targetType to be more strict about what methods are supported ?
+      if (canAssignToFrom(targetType, setSpecificsConstraints(m, getReturnType(m)), false)) {
+        SpecificHaxeClassReference type = getImplicitCastFromType(m);
+        if (type != null) {
+          list.add(type);
+        }
+      }
+    }
+    return list;
   }
 
   @Nullable
   private SpecificHaxeClassReference getImplicitCastFromType(@NotNull HaxeMethodModel methodModel) {
     SpecificHaxeClassReference parameter = getTypeOfFirstParameter(methodModel);
     if (parameter == null) return null;
-    return SetSpecificsConstraints(methodModel, parameter);
+    return setSpecificsConstraints(methodModel, parameter);
   }
 
   @NotNull
-  private SpecificHaxeClassReference SetSpecificsConstraints(@NotNull HaxeMethodModel methodModel, @NotNull SpecificHaxeClassReference classReference) {
+  private SpecificHaxeClassReference setSpecificsConstraints(@NotNull HaxeMethodModel methodModel, @NotNull SpecificHaxeClassReference classReference) {
     ResultHolder[] specifics = classReference.getGenericResolver().getSpecifics();
     ResultHolder[] newSpecifics = applyConstraintsToSpecifics(methodModel, specifics);
 
@@ -478,10 +487,13 @@ public class HaxeClassModel implements HaxeExposableModel {
     HaxePsiCompositeElement body = PsiTreeUtil.getChildOfAnyType(haxeClass, isEnum() ? HaxeEnumBody.class : HaxeClassBody.class, HaxeInterfaceBody.class);
 
     if (body != null) {
-      return PsiTreeUtil.getChildrenOfAnyType(body, HaxeFieldDeclaration.class, HaxeAnonymousTypeField.class, HaxeEnumValueDeclaration.class)
-        .stream()
-        .map(HaxeFieldModel::new)
-        .collect(toList());
+      List<HaxeFieldModel> list = new ArrayList<>();
+      List<HaxePsiField> children = PsiTreeUtil.getChildrenOfAnyType(body, HaxeFieldDeclaration.class, HaxeAnonymousTypeField.class, HaxeEnumValueDeclaration.class);
+      for (HaxePsiField field : children) {
+        HaxeFieldModel model = new HaxeFieldModel(field);
+        list.add(model);
+      }
+      return list;
     } else {
       return Collections.emptyList();
     }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeImportModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeImportModel.java
@@ -127,16 +127,21 @@ public class HaxeImportModel extends HaxeImportableModel {
   }
 
   @Override
+  @Nullable
   protected HaxeModel getExposedMember(String name) {
     List<? extends HaxeModel> members = getExposedMembers();
     if (members.isEmpty()) return null;
     if (hasAlias()) {
       return (Objects.equals(getAliasName(), name)) ? members.get(0) : null;
     }
-    return members.stream()
-      .filter(model -> name.equals(model.getName()))
-      .findFirst()
-      .orElse(null);
+
+    for(HaxeModel member : members) {
+      if(name.equals(member.getName())){
+        return member;
+      }
+    }
+    return null;
+
   }
 
   @Override

--- a/src/common/com/intellij/plugins/haxe/model/HaxeImportableModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeImportableModel.java
@@ -74,18 +74,19 @@ public abstract class HaxeImportableModel implements HaxeExposableModel {
   @NotNull
   @Override
   public List<HaxeModel> getExposedMembers() {
-    List<HaxeModel> exposed = CachedValuesManager.getCachedValue(getBasePsi(), exposedMembersCollector(this));
-    return exposed;
+    return CachedValuesManager.getCachedValue(getBasePsi(), exposedMembersCollector(this));
   }
 
   @Nullable
   protected HaxeModel getExposedMember(String name) {
     List<? extends HaxeModel> members = getExposedMembers();
     if (members.isEmpty()) return null;
-    return members.stream()
-      .filter(model -> name.equals(model.getName()))
-      .findFirst()
-      .orElse(null);
+    for (HaxeModel model : members) {
+      if (name.equals(model.getName())) {
+        return model;
+      }
+    }
+    return null;
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/model/HaxePackageModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxePackageModel.java
@@ -26,10 +26,7 @@ import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class HaxePackageModel implements HaxeExposableModel {
@@ -154,20 +151,23 @@ public class HaxePackageModel implements HaxeExposableModel {
     return null;
   }
 
+  @NotNull
   @Override
   public List<HaxeModel> getExposedMembers() {
     PsiDirectory directory = root.access(path);
     if (directory != null) {
       PsiFile[] files = directory.getFiles();
 
-      return Arrays.stream(files)
-        .filter(file -> file instanceof HaxeFile)
-        .flatMap(file -> {
+      List<HaxeModel>  result = new ArrayList<>();
+      for(PsiFile file : files) {
+        if( file instanceof HaxeFile) {
           HaxeFileModel fileModel = HaxeFileModel.fromElement(file);
-          return fileModel != null ? fileModel.getExposedMembers().stream() : null;
-        })
-        .filter(Objects::nonNull)
-        .collect(Collectors.toList());
+          if(fileModel != null)result.addAll(fileModel.getExposedMembers());
+        }
+      }
+
+
+      return result;
     }
 
     return Collections.emptyList();

--- a/src/common/com/intellij/plugins/haxe/model/HaxeSourceRootModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeSourceRootModel.java
@@ -71,6 +71,7 @@ public class HaxeSourceRootModel {
     return current;
   }
 
+  @Nullable
   public HaxeModel resolve(FullyQualifiedInfo info) {
     if (rootPackage == null) {
       return null;

--- a/src/common/com/intellij/plugins/haxe/model/fixer/HaxeTypeTagChangeFixer.java
+++ b/src/common/com/intellij/plugins/haxe/model/fixer/HaxeTypeTagChangeFixer.java
@@ -36,7 +36,7 @@ public class HaxeTypeTagChangeFixer extends HaxeFixer {
     this.result = result;
   }
 
-  public HaxeTypeTagChangeFixer(HaxeTypeTag typeTag, SpecificTypeReference result) {
+  public HaxeTypeTagChangeFixer(@NotNull HaxeTypeTag typeTag, @NotNull SpecificTypeReference result) {
     this(null, typeTag, result);
   }
 

--- a/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/SpecificHaxeClassReference.java
@@ -75,11 +75,11 @@ public class SpecificHaxeClassReference extends SpecificTypeReference {
   }
 
   public static SpecificHaxeClassReference withGenerics(@NotNull HaxeClassReference clazz, ResultHolder[] specifics) {
-    return new SpecificHaxeClassReference(clazz, specifics, null, null, clazz.elementContext);
+      return new SpecificHaxeClassReference(clazz, specifics != null ?  specifics : ResultHolder.EMPTY, null, null, clazz.elementContext);
   }
 
   public static SpecificHaxeClassReference withGenerics(@NotNull HaxeClassReference clazz, ResultHolder[] specifics, Object constantValue) {
-    return new SpecificHaxeClassReference(clazz, specifics, constantValue, null, clazz.elementContext);
+    return new SpecificHaxeClassReference(clazz,  specifics != null ?  specifics : ResultHolder.EMPTY, constantValue, null, clazz.elementContext);
   }
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/util/HaxeImportUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeImportUtil.java
@@ -41,15 +41,27 @@ public class HaxeImportUtil {
 
     List<HaxeImportStatement> allImportStatements = ((HaxeFile)file).getImportStatements();
 
-    final boolean hasWildcards = allImportStatements.stream().anyMatch(statement -> statement.getModel().hasWildcard());
+    boolean hasWildcards = false;
+    for (HaxeImportStatement allImportStatement : allImportStatements) {
+      if (allImportStatement.getModel().hasWildcard()) {
+        hasWildcards = true;
+        break;
+      }
+    }
 
-    List<HaxeImportStatement> usefulStatements = allImportStatements
-      .stream()
-      .filter(statement -> externalReferences
-        .stream()
-        .anyMatch(referencedElement -> isStatementExposesReference(statement, referencedElement)))
-      .distinct()
-      .collect(Collectors.toList());
+    List<HaxeImportStatement> usefulStatements = new ArrayList<>();
+    Set<HaxeImportStatement> uniqueValues = new HashSet<>();
+
+    for (HaxeImportStatement statement : allImportStatements) {
+      for (PsiElement referencedElement : externalReferences) {
+        if (isStatementExposesReference(statement, referencedElement)) {
+            if (uniqueValues.add(statement)) {
+              usefulStatements.add(statement);
+            }
+          break;
+        }
+      }
+    }
 
     if (hasWildcards) {
       removeUnusedWildcards(externalReferences, usefulStatements);

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -999,16 +999,12 @@ public class HaxeResolveUtil {
 
   @Nullable
   public static PsiElement searchInSpecifiedImports(HaxeFileModel file, String name) {
-
-    HaxeImportableModel importModel = StreamUtil.reverse(file.getOrderedImportAndUsingModels().stream())
-      .filter(model -> {
-        PsiElement exposedItem = model.exposeByName(name);
-        return exposedItem != null;
-      })
-      .findFirst().orElse(null);
-
-    if (importModel != null) {
-      return importModel.exposeByName(name);
+    List<HaxeImportableModel> models = file.getOrderedImportAndUsingModels();
+    for(HaxeImportableModel model : models) {
+      PsiElement element = model.exposeByName(name);
+      if(element != null) {
+        return element;
+      }
     }
     return null;
   }
@@ -1066,23 +1062,25 @@ public class HaxeResolveUtil {
   @Nullable
   public static PsiElement searchInSamePackage(@NotNull HaxeFileModel file, @NotNull String name) {
     final HaxePackageModel packageModel = file.getPackageModel();
-    HaxeModel result = null;
-
     if (packageModel != null) {
-      result = packageModel.getExposedMembers().stream()
-        .filter(model -> name.equals(model.getName()))
-        .findFirst()
-        .orElse(null);
+      for (HaxeModel model : packageModel.getExposedMembers()) {
+        if (name.equals(model.getName())) {
+          return model.getBasePsi();
+        }
+      }
     }
-
-    return result != null ? result.getBasePsi() : null;
+    return null;
   }
 
   public static String getQName(PsiElement[] fileChildren, final String result, boolean searchInSamePackage) {
-    final HaxeClass classForType = (HaxeClass)Arrays.stream(fileChildren)
-      .filter(child -> child instanceof HaxeClass && result.equals(((HaxeClass)child).getName()))
-      .findFirst()
-      .orElse(null);
+
+    HaxeClass classForType = null;
+    for(PsiElement child: fileChildren) {
+      if( child instanceof HaxeClass && result.equals(((HaxeClass)child).getName())){
+        classForType = (HaxeClass)child;
+        break;
+      }
+    }
 
     if (classForType != null) {
       return classForType.getQualifiedName();

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -1000,7 +1000,8 @@ public class HaxeResolveUtil {
   @Nullable
   public static PsiElement searchInSpecifiedImports(HaxeFileModel file, String name) {
     List<HaxeImportableModel> models = file.getOrderedImportAndUsingModels();
-    for(HaxeImportableModel model : models) {
+    for (int i = models.size() - 1; i >= 0; i--) {
+      HaxeImportableModel model = models.get(i);
       PsiElement element = model.exposeByName(name);
       if(element != null) {
         return element;


### PR DESCRIPTION
i was looking at the performance and saw  that a lot of heave used  methods where using streams for very simple operations. 
while the overhead is not much it will probably affect performance so i have converted them to  for loops so we can save some memory allocation and method calls. (i also did some small refactoring  for null-safety)