### PR TITLE
adding option  to resolve type parameters when showing presentableTex…

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
@@ -33,6 +33,8 @@ import com.intellij.plugins.haxe.model.HaxeMemberModel;
 import com.intellij.plugins.haxe.model.HaxeBaseMemberModel;
 import com.intellij.plugins.haxe.model.HaxeMethodContext;
 import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
+import com.intellij.plugins.haxe.model.type.ResultHolder;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -82,6 +84,7 @@ public class HaxeLookupElement extends LookupElement {
       presentation.setItemText(getLookupString());
       return;
     }
+    HaxeGenericResolver resolver =  leftReference == null ? null :leftReference.getGenericResolver();;
 
     String presentableText = myComponentNamePresentation.getPresentableText();
 
@@ -89,8 +92,7 @@ public class HaxeLookupElement extends LookupElement {
     HaxeBaseMemberModel model = HaxeBaseMemberModel.fromPsi(myComponentName);
 
     if (model != null) {
-      // TODO: Specialization support required
-      presentableText = model.getPresentableText(context);
+      presentableText = model.getPresentableText(context, resolver);
 
       // Check deprecated modifiers
       if (model instanceof HaxeMemberModel && ((HaxeMemberModel)model).getModifiers().hasModifier(HaxePsiModifier.DEPRECATED)) {

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeSemanticAnnotator.java
@@ -1463,7 +1463,7 @@ class MethodChecker {
                                         : "haxe.semantic.overwritten.method.parameter.optional";
         }
 
-        errorMessage = HaxeBundle.message(errorMessage, parentParam.getPresentableText(),
+        errorMessage = HaxeBundle.message(errorMessage, parentParam.getPresentableText(scopeResolver),
                                           parentMethod.getDeclaringClass().getName() + "." + parentMethod.getName());
 
         final Annotation annotation = holder.createErrorAnnotation(currentParam.getBasePsi(), errorMessage);

--- a/src/common/com/intellij/plugins/haxe/model/HaxeBaseMemberModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeBaseMemberModel.java
@@ -101,11 +101,15 @@ public abstract class HaxeBaseMemberModel implements HaxeModel {
     return HaxeTypeResolver.getFieldOrMethodReturnType((AbstractHaxeNamedComponent)this.basePsi);
   }
 
-  public ResultHolder getResultType(HaxeGenericResolver resolver) {
+  public ResultHolder getResultType(@Nullable HaxeGenericResolver resolver) {
     return HaxeTypeResolver.getFieldOrMethodReturnType((AbstractHaxeNamedComponent)this.basePsi, resolver);
   }
 
   public String getPresentableText(HaxeMethodContext context) {
+      return getPresentableText(context, null);
+  }
+
+  public String getPresentableText(HaxeMethodContext context, @Nullable HaxeGenericResolver resolver) {
     PsiElement basePsi = getBasePsi();
     if (basePsi instanceof HaxeNamedComponent) {
       AbstractHaxeNamedComponent nc = (AbstractHaxeNamedComponent)basePsi;

--- a/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeMethodModel.java
@@ -114,18 +114,22 @@ public class HaxeMethodModel extends HaxeMemberModel implements HaxeExposableMod
 
   @Override
   public String getPresentableText(HaxeMethodContext context) {
+    return getPresentableText(context, null);
+  }
+  @Override
+  public String getPresentableText(HaxeMethodContext context, @Nullable HaxeGenericResolver resolver) {
     String out = "";
     out += this.getName();
     out += "(";
     int index = 0;
     for (HaxeParameterModel param : this.getParametersWithContext(context)) {
       if (index > 0) out += ", ";
-      out += param.getPresentableText();
+      out += param.getPresentableText(resolver);
       index++;
     }
     out += ")";
     if (!isConstructor()) {
-      out += ":" + getResultType();
+      out += ":" + getResultType(resolver);
     }
     return out;
   }

--- a/src/common/com/intellij/plugins/haxe/model/HaxeParameterModel.java
+++ b/src/common/com/intellij/plugins/haxe/model/HaxeParameterModel.java
@@ -110,11 +110,11 @@ public class HaxeParameterModel extends HaxeBaseMemberModel implements HaxeModel
     return model;
   }
 
-  public String getPresentableText() {
+  public String getPresentableText(@Nullable HaxeGenericResolver resolver) {
     String out = hasOptionalPsi() ? "?" : "";
     out += getName();
     out += ":";
-    out += getType().toStringWithoutConstant();
+    out += getType(resolver).toStringWithoutConstant();
     return out;
   }
 
@@ -143,7 +143,11 @@ public class HaxeParameterModel extends HaxeBaseMemberModel implements HaxeModel
 
   @Override
   public String getPresentableText(HaxeMethodContext context) {
-    final ResultHolder type = getResultType();
+    return getPresentableText(context, null);
+  }
+  @Override
+  public String getPresentableText(HaxeMethodContext context, HaxeGenericResolver resolver) {
+    final ResultHolder type = getResultType(resolver);
     return type == null ? this.getName() : this.getName() + ":" + type;
   }
 


### PR DESCRIPTION
It looks like auto-completion at some point lost the ability to show suggestions with  type parameters resolved.
This PR will bring back this feature.

before:
![image](https://user-images.githubusercontent.com/3193925/104216937-00505380-543b-11eb-9246-89acefd671b4.png)

after:
![image](https://user-images.githubusercontent.com/3193925/104216506-6ee0e180-543a-11eb-8cbf-d30f9183d804.png)
