### PR TITLE
Make resolvers skip Null<T> "scope" when resolving null<T> forwarded members.

### DIFF
--- a/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeLookupElement.java
@@ -33,11 +33,14 @@ import com.intellij.plugins.haxe.model.HaxeMemberModel;
 import com.intellij.plugins.haxe.model.HaxeBaseMemberModel;
 import com.intellij.plugins.haxe.model.HaxeMethodContext;
 import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+
+import static com.intellij.plugins.haxe.model.type.HaxeGenericResolverUtil.getResolverSkipAbstractNullScope;
 
 /**
  * @author: Fedor.Korotkov
@@ -81,6 +84,10 @@ public class HaxeLookupElement extends LookupElement {
     if (myComponentNamePresentation == null) {
       presentation.setItemText(getLookupString());
       return;
+    }
+    HaxeGenericResolver resolver =  null;
+    if(leftReference != null && leftReference.getHaxeClass() != null) {
+      resolver = getResolverSkipAbstractNullScope(leftReference.getHaxeClass().getModel(), leftReference.getGenericResolver());
     }
 
     String presentableText = myComponentNamePresentation.getPresentableText();

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -51,7 +51,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.intellij.openapi.util.text.StringUtil.defaultIfEmpty;
-import static com.intellij.plugins.haxe.model.type.SpecificTypeReference.*;
 
 abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements HaxeReference {
 
@@ -487,10 +486,10 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
         // creating a resolver that combines parent(leftExpression) current(expression) and children (parameterExpressions)
         HaxeGenericResolver resolver = new HaxeGenericResolver();
 
-        if(leftResult.getHaxeClass() != null) {
+        if (leftResult.getHaxeClass() != null) {
           resolver.addAll(HaxeGenericResolverUtil
                             .getResolverSkipAbstractNullScope(leftResult.getHaxeClass().getModel(), leftResult.getGenericResolver()));
-        }else {
+        } else {
           resolver.addAll(leftResult.getGenericResolver());
         }
         PsiElement resolvedExpression = ((HaxeReference)expression).resolve();
@@ -629,9 +628,14 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
         HaxeGenericParam genericParam = method.getGenericParam();
         List<HaxeGenericListPart> partList =genericParam != null ? genericParam.getGenericListPartList() : null;
         if(partList!= null) {
-          Optional<HaxeGenericListPart> match = partList.stream().filter(part -> Objects.equals(typeName, part.getName())).findFirst();
-          if(match.isPresent()) {
-            HaxeGenericListPart listPart = match.get();
+          HaxeGenericListPart listPart = null;
+          for (HaxeGenericListPart genericListPart : partList) {
+            if (Objects.equals(typeName, genericListPart.getName())) {
+              listPart = genericListPart;
+              break;
+            }
+          }
+          if(listPart!= null) {
             HaxeTypeList list = listPart.getTypeList();
             if(list != null) {
               list.getTypeListPartList();

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeReferenceImpl.java
@@ -639,10 +639,13 @@ abstract public class HaxeReferenceImpl extends HaxeExpressionImpl implements Ha
             HaxeTypeList list = listPart.getTypeList();
             if(list != null) {
               list.getTypeListPartList();
-              List<HaxeType> classReferences = list.getTypeListPartList().stream()
-                .map(part -> part.getTypeOrAnonymous() == null ? null : part.getTypeOrAnonymous().getType())
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList());
+              List<HaxeType> classReferences = new ArrayList<>();
+              for (HaxeTypeListPart part : list.getTypeListPartList()) {
+                HaxeType type = part.getTypeOrAnonymous() == null ? null : part.getTypeOrAnonymous().getType();
+                if (type != null) {
+                  classReferences.add(type);
+                }
+              }
 
               HaxeTypeParameterMultiType constraint = new HaxeTypeParameterMultiType(listPart.getContext().getNode(), classReferences);
               return HaxeClassResolveResult.create(constraint);

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeExpressionEvaluator.java
@@ -304,7 +304,7 @@ public class HaxeExpressionEvaluator {
 
       ResultHolder result = typeTag != null ? typeTagResult : initResult;
 
-      if (init != null) {
+      if (init != null && typeTag != null) {
         if (!typeTagResult.canAssign(initResult)) {
           context.addError(
             element,
@@ -315,9 +315,7 @@ public class HaxeExpressionEvaluator {
         }
       }
 
-      if (name != null) {
-        context.setLocal(name.getText(), result);
-      }
+      context.setLocal(name.getText(), result);
 
       return result;
     }

--- a/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolverUtil.java
+++ b/src/common/com/intellij/plugins/haxe/model/type/HaxeGenericResolverUtil.java
@@ -188,9 +188,12 @@ public class HaxeGenericResolverUtil {
     if (model instanceof HaxeAbstractClassModel) {
       HaxeAbstractClassModel abstractClassModel = (HaxeAbstractClassModel)model;
       if ("Null".equals(abstractClassModel.getName()) && abstractClassModel.isCoreType()) {
-        HaxeGenericListPart generic = abstractClassModel.getAbstractClass().getGenericParam().getGenericListPartList().get(0);
-        ResultHolder resolve = resolver.resolve(generic.getName());
-        return  resolve == null  || resolve.getClassType() == null ? resolver : resolve.getClassType().getGenericResolver();
+        HaxeGenericParam param = abstractClassModel.getAbstractClass().getGenericParam();
+        if (param != null) {
+          HaxeGenericListPart generic = param.getGenericListPartList().get(0);
+          ResultHolder resolve = resolver.resolve(generic.getName());
+          return resolve == null || resolve.getClassType() == null ? resolver : resolve.getClassType().getGenericResolver();
+        }
       }
     }
     return resolver;

--- a/src/common/com/intellij/plugins/haxe/util/HaxeAbstractForwardUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeAbstractForwardUtil.java
@@ -38,6 +38,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import static com.intellij.plugins.haxe.model.type.HaxeGenericResolverUtil.getResolverSkipAbstractNullScope;
+
 /**
  * Extensions for resolving and analyzing @:forward abstract meta
  */
@@ -56,7 +58,9 @@ public class HaxeAbstractForwardUtil {
       final HaxeClass underlyingClass = abstractClassModel.getUnderlyingClass(resolver);
       if (underlyingClass != null) {
         if (forwardingFieldsNames.isEmpty()) {
-          return HaxeResolveUtil.findNamedSubComponents(resolver, underlyingClass);
+          HaxeGenericResolver forwardResolver = resolver != null ? resolver : new HaxeGenericResolver();
+          forwardResolver = getResolverSkipAbstractNullScope(abstractClassModel, forwardResolver);
+          return HaxeResolveUtil.findNamedSubComponents(forwardResolver, underlyingClass);
         }
         List<HaxeNamedComponent> haxeNamedComponentList = new ArrayList<>();
         for (String fieldName : forwardingFieldsNames) {


### PR DESCRIPTION
since methods from T in null<T> are forwarded as if Null does not exists we need make the resolvers skip the Null<T> "scope" for proper type Parameter resolving  for forwarded members. these code changes should fix that.