### PR TITLE
handle null value from HaxeLibrary.load()

### DIFF
--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxeLibrary.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxeLibrary.java
@@ -196,6 +196,8 @@ public class HaxeLibrary {
       return new HaxeLibrary(libName, libraryRoot, owner);
     } catch (InvalidParameterException e) {
       ; // libName must not have been an url
+    } catch (Exception e) {
+      LOG.error("Unable to read Haxelib '" + libName +"' reason:" + e.getMessage(), e);
     }
     return null;
   }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
@@ -112,10 +112,11 @@ public final class HaxelibLibraryCache {
 
         // It's not in the cache, so go get it and cache the results.
         HaxeLibrary newlib = HaxeLibrary.load(this, libraryName, mySdk);
-        myCache.add(newlib);
-
-        timeLog.stamp("Finished loading library: " + libraryName);
-        return newlib.getClasspathEntries();
+        if(null != newlib) {
+          myCache.add(newlib);
+          timeLog.stamp("Finished loading library: " + libraryName);
+          return newlib.getClasspathEntries();
+        }
       }
 
       timeLog.stamp("Unknown library !!!  " + libraryName + " !!! ");


### PR DESCRIPTION
This should hopefully fix a nullpointer issue that occurs when a haxelib.json is corrupt or a lib fails to load.
i also added error logging to make it easier to see what lib failed.

![image](https://user-images.githubusercontent.com/3193925/107877749-8e05df80-6ece-11eb-9437-eaeaa1eecb2e.png)
