### PR TITLE
fixing IDE freeze and missing HXML completion

### DIFF
--- a/grammar/hxml.bnf
+++ b/grammar/hxml.bnf
@@ -31,8 +31,16 @@ private line_recovery ::= !(eol_)
 private option_ ::= (lib | define | classpath | main | property | COMMENT)
 
 property ::= option value? {pin=1}
-define ::= '-D' value {pin=1}
-lib ::= '-lib' value (':' value)? {pin=1}
-classpath ::= '-cp' value {pin=1}
-main ::= '-main' qualifiedName {pin=1}
+define ::= ('-D'|'--define') value {pin=1}
 
+lib ::= (libHx3|libHx4) value (':' value)? {pin=1}
+private libHx3 ::= '-lib'
+private libHx4 ::= '-L'|'--library'
+
+classpath ::= (classpathHx3|classpathHx4) value {pin=1}
+private classpathHx3 ::= '-cp'
+private classpathHx4 ::= '-p'
+
+main ::= (mainHx3| mainHx4) qualifiedName {pin=1}
+private mainHx3 ::= '-main'
+private mainHx4 ::= '-m'| '--main'

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -85,6 +85,8 @@
   <![CDATA[
       <p>Unreleased changes</p>
       <ul>
+        <li>Add HXML completion for Haxe 4</li>
+        <li>Fixed issue where IDE would freeze when writing HXML files</li>
         <li>Add HashLink target</li>
         <li>improved block-statement parsing and added quickfix for missing semicolon</li>
         <li>Add support for import.hx</li>

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibCommandUtils.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibCommandUtils.java
@@ -205,43 +205,6 @@ public class HaxelibCommandUtils {
     return strings;
   }
 
-
-  //private static Logger log = Logger.getInstance(HaxelibCommandUtils.class);
-
-  public static List<String> getProcessStderr(ArrayList<String> commandLineArguments, File dir, @Nullable HaxeSdkAdditionalDataBase haxeSdkData) {
-    List<String> strings = new ArrayList<String>();
-
-    try {
-      ProcessBuilder builder = HaxeSdkUtilBase.createProcessBuilder(commandLineArguments, dir, haxeSdkData);
-      Process process = builder.start();
-      InputStreamReader reader = new InputStreamReader(process.getErrorStream());
-      Scanner scanner = new Scanner(reader);
-
-
-      if(reader.ready()) {
-        while (scanner.hasNextLine()) {
-          String nextLine = scanner.nextLine();
-          strings.add(nextLine);
-        }
-      }
-
-      if(process.isAlive()) {
-        if(!process.waitFor(10, TimeUnit.MILLISECONDS)) {
-          process.destroy();
-        }
-      }
-
-
-    }
-    catch (IOException | InterruptedException e) {
-      e.printStackTrace();
-      //log.error(StringUtil.getMessage(e));
-    }
-
-    return strings;
-  }
-
-
   /**
    * Run a shell command in the (IDEA's) current directory, capturing its standard output.
    *
@@ -251,10 +214,6 @@ public class HaxelibCommandUtils {
   @NotNull
   public static List<String> getProcessStdout(@NotNull ArrayList<String> commandLineArguments, @Nullable HaxeSdkAdditionalDataBase haxeSdkData) {
     return getProcessStdout(commandLineArguments, null, haxeSdkData);
-  }
-
-  public static List<String> getProcessStderr(ArrayList<String> commandLineArguments, @Nullable HaxeSdkAdditionalDataBase haxeSdkData) {
-    return getProcessStderr(commandLineArguments, null, haxeSdkData);
   }
 
 }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibCommandUtils.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibCommandUtils.java
@@ -39,6 +39,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Scanner;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Utilities to run the haxelib command and capture its output.
@@ -180,32 +181,24 @@ public class HaxelibCommandUtils {
       Process process = builder.start();
       InputStreamReader reader = new InputStreamReader(process.getInputStream());
       Scanner scanner = new Scanner(reader);
+      process.waitFor(100, TimeUnit.MILLISECONDS);
 
-      while (scanner.hasNextLine()) {
-        String nextLine = scanner.nextLine();
-        strings.add(nextLine);
-      }
-      process.waitFor();
-
-      /*
-      try {
-        Thread.sleep(250);
-        try {
-          process.exitValue();
+      if(reader.ready()) {
+        while (scanner.hasNextLine()) {
+          String nextLine = scanner.nextLine();
+          strings.add(nextLine);
         }
-        catch (IllegalThreadStateException e) {
+      }
+
+      if(process.isAlive()) {
+        if(!process.waitFor(10, TimeUnit.MILLISECONDS)) {
           process.destroy();
         }
       }
-      catch (InterruptedException e) {
-        e.printStackTrace();
-      }
-      */
+
+
     }
-    catch (IOException e) {
-      e.printStackTrace();
-    }
-    catch (InterruptedException e) {
+    catch (IOException | InterruptedException e) {
       e.printStackTrace();
     }
 
@@ -224,34 +217,23 @@ public class HaxelibCommandUtils {
       InputStreamReader reader = new InputStreamReader(process.getErrorStream());
       Scanner scanner = new Scanner(reader);
 
-      while (scanner.hasNextLine()) {
-        String nextLine = scanner.nextLine();
-        strings.add(nextLine);
+
+      if(reader.ready()) {
+        while (scanner.hasNextLine()) {
+          String nextLine = scanner.nextLine();
+          strings.add(nextLine);
+        }
       }
 
-      //log.error(StringUtil.join(strings, "\n"));
-      process.waitFor();
-
-      /*
-      try {
-        Thread.sleep(250);
-        try {
-          process.exitValue();
-        }
-        catch (IllegalThreadStateException e) {
+      if(process.isAlive()) {
+        if(!process.waitFor(10, TimeUnit.MILLISECONDS)) {
           process.destroy();
         }
       }
-      catch (InterruptedException e) {
-        e.printStackTrace();
-      }
-      */
+
+
     }
-    catch (IOException e) {
-      e.printStackTrace();
-      //log.error(StringUtil.getMessage(e));
-    }
-    catch (InterruptedException e) {
+    catch (IOException | InterruptedException e) {
       e.printStackTrace();
       //log.error(StringUtil.getMessage(e));
     }

--- a/src/common/com/intellij/plugins/haxe/ide/HXMLDefineCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HXMLDefineCompletionContributor.java
@@ -29,23 +29,33 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 
+import static com.intellij.patterns.PlatformPatterns.psiElement;
+
 /**
  * Created by as3boyan on 19.11.14.
  */
 public class HXMLDefineCompletionContributor extends CompletionContributor {
   public HXMLDefineCompletionContributor() {
     final List<HXMLCompletionItem> defines = HaxeHelpCache.getInstance().getDefines();
-    extend(CompletionType.BASIC, PlatformPatterns.psiElement().withParent(HXMLValue.class).withSuperParent(2, HXMLDefine.class),
-           new CompletionProvider<CompletionParameters>() {
-             @Override
-             protected void addCompletions(@NotNull CompletionParameters parameters,
-                                           ProcessingContext context,
-                                           @NotNull CompletionResultSet result) {
-               for (int i = 0; i < defines.size(); i++) {
-                 HXMLCompletionItem completionItem = defines.get(i);
-                 result.addElement(LookupElementBuilder.create(completionItem.name).withTailText(" " + completionItem.description, true));
-               }
-             }
-           });
+
+    // intelliJ 2018 and older
+    extend(CompletionType.BASIC, PlatformPatterns.psiElement(HXMLTypes.VALUE).withParent(HXMLDefine.class), getProvider(defines));
+    // intelliJ 2019 and newer
+    extend(CompletionType.BASIC, PlatformPatterns.psiElement().withParent(HXMLValue.class).withSuperParent(2, HXMLDefine.class), getProvider(defines));
+  }
+
+  @NotNull
+  private CompletionProvider<CompletionParameters> getProvider(List<HXMLCompletionItem> defines) {
+    return new CompletionProvider<CompletionParameters>() {
+      @Override
+      protected void addCompletions(@NotNull CompletionParameters parameters,
+                                    ProcessingContext context,
+                                    @NotNull CompletionResultSet result) {
+        for (int i = 0; i < defines.size(); i++) {
+          HXMLCompletionItem completionItem = defines.get(i);
+          result.addElement(LookupElementBuilder.create(completionItem.name).withTailText(" " + completionItem.description, true));
+        }
+      }
+    };
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/HXMLDefineCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HXMLDefineCompletionContributor.java
@@ -22,6 +22,7 @@ import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.plugins.haxe.hxml.psi.HXMLDefine;
 import com.intellij.plugins.haxe.hxml.psi.HXMLTypes;
+import com.intellij.plugins.haxe.hxml.psi.HXMLValue;
 import com.intellij.plugins.haxe.util.HaxeHelpCache;
 import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +35,7 @@ import java.util.List;
 public class HXMLDefineCompletionContributor extends CompletionContributor {
   public HXMLDefineCompletionContributor() {
     final List<HXMLCompletionItem> defines = HaxeHelpCache.getInstance().getDefines();
-    extend(CompletionType.BASIC, PlatformPatterns.psiElement(HXMLTypes.VALUE).withParent(HXMLDefine.class),
+    extend(CompletionType.BASIC, PlatformPatterns.psiElement().withParent(HXMLValue.class).withSuperParent(2, HXMLDefine.class),
            new CompletionProvider<CompletionParameters>() {
              @Override
              protected void addCompletions(@NotNull CompletionParameters parameters,

--- a/src/common/com/intellij/plugins/haxe/ide/HXMLHaxelibCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HXMLHaxelibCompletionContributor.java
@@ -20,10 +20,13 @@ package com.intellij.plugins.haxe.ide;
 import com.intellij.codeInsight.completion.*;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.patterns.PlatformPatterns;
 import com.intellij.plugins.haxe.haxelib.HaxelibCache;
 import com.intellij.plugins.haxe.hxml.HXMLLanguage;
 import com.intellij.plugins.haxe.hxml.psi.HXMLLib;
+import com.intellij.plugins.haxe.hxml.psi.HXMLTokenType;
 import com.intellij.plugins.haxe.hxml.psi.HXMLTypes;
+import com.intellij.plugins.haxe.hxml.psi.HXMLValue;
 import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -46,7 +49,7 @@ public class HXMLHaxelibCompletionContributor extends CompletionContributor {
     availableHaxelibs = haxelibCache.getAvailableHaxelibs();
     localHaxelibs = haxelibCache.getLocalHaxelibs();
 
-    extend(CompletionType.BASIC, psiElement(HXMLTypes.VALUE).withParent(HXMLLib.class).withLanguage(HXMLLanguage.INSTANCE),
+    extend(CompletionType.BASIC, PlatformPatterns.psiElement().withParent(HXMLValue.class).withSuperParent(2, HXMLLib.class).withLanguage(HXMLLanguage.INSTANCE),
            new CompletionProvider<CompletionParameters>() {
              @Override
              protected void addCompletions(@NotNull CompletionParameters parameters,

--- a/src/common/com/intellij/plugins/haxe/ide/HXMLHaxelibCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HXMLHaxelibCompletionContributor.java
@@ -49,22 +49,29 @@ public class HXMLHaxelibCompletionContributor extends CompletionContributor {
     availableHaxelibs = haxelibCache.getAvailableHaxelibs();
     localHaxelibs = haxelibCache.getLocalHaxelibs();
 
-    extend(CompletionType.BASIC, PlatformPatterns.psiElement().withParent(HXMLValue.class).withSuperParent(2, HXMLLib.class).withLanguage(HXMLLanguage.INSTANCE),
-           new CompletionProvider<CompletionParameters>() {
-             @Override
-             protected void addCompletions(@NotNull CompletionParameters parameters,
-                                           ProcessingContext context,
-                                           @NotNull CompletionResultSet result) {
-               for (int i = 0; i < availableHaxelibs.size(); i++) {
-                 result.addElement(LookupElementBuilder.create(availableHaxelibs.get(i))
-                                     .withTailText(" available at haxelib", true));
-               }
+    // intelliJ 2018 and older
+    extend(CompletionType.BASIC, psiElement(HXMLTypes.VALUE).withParent(HXMLLib.class).withLanguage(HXMLLanguage.INSTANCE),  getProvider());
+    // intelliJ 2019 and newer
+    extend(CompletionType.BASIC, PlatformPatterns.psiElement().withParent(HXMLValue.class).withSuperParent(2, HXMLLib.class).withLanguage(HXMLLanguage.INSTANCE), getProvider());
+  }
 
-               for (int i = 0; i < localHaxelibs.size(); i++) {
-                 result.addElement(LookupElementBuilder.create(localHaxelibs.get(i))
-                                     .withTailText(" installed", true));
-               }
-             }
-           });
+  @NotNull
+  private CompletionProvider<CompletionParameters> getProvider() {
+    return new CompletionProvider<CompletionParameters>() {
+      @Override
+      protected void addCompletions(@NotNull CompletionParameters parameters,
+                                    ProcessingContext context,
+                                    @NotNull CompletionResultSet result) {
+        for (int i = 0; i < availableHaxelibs.size(); i++) {
+          result.addElement(LookupElementBuilder.create(availableHaxelibs.get(i))
+                              .withTailText(" available at haxelib", true));
+        }
+
+        for (int i = 0; i < localHaxelibs.size(); i++) {
+          result.addElement(LookupElementBuilder.create(localHaxelibs.get(i))
+                              .withTailText(" installed", true));
+        }
+      }
+    };
   }
 }


### PR DESCRIPTION
auto completion  in HXML would freeze the IDE when trying to get compiler argument suggestions.  some completion contributors no loner worked in 2019 and newer. it looks like the psiElement used with pattern matching has changed and is one element deeper.

i also added logic to parse and use haxe 4 values in HXML files.