### PR TITLE
Dont try to resolve generics for classes that dont have generics.

### DIFF
--- a/src/common/com/intellij/plugins/haxe/lang/psi/HaxeClassResolveResult.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/HaxeClassResolveResult.java
@@ -290,10 +290,13 @@ public class HaxeClassResolveResult implements Cloneable {
     HaxeClassReference classReference = null != clazz ? new HaxeClassReference(clazz, context)
                                         : new HaxeClassReference(SpecificHaxeClassReference.UNKNOWN, context);
     HaxeClass clazzPsi = null != clazz ? clazz.getPsi() : null;
-
     softMerge(HaxeGenericSpecialization.fromGenericResolver(clazzPsi, resolver));
-    HaxeGenericResolver newResolver = getGenericResolver();
-    return SpecificHaxeClassReference.withGenerics(classReference, newResolver.getSpecificsFor(clazzPsi));
+    if(classReference.getHaxeClass().isGeneric()) {
+      HaxeGenericResolver newResolver = getGenericResolver();
+      return SpecificHaxeClassReference.withGenerics(classReference, newResolver.getSpecificsFor(clazzPsi));
+    }else {
+      return SpecificHaxeClassReference.withoutGenerics(classReference);
+    }
   }
 
   public void specialize(@Nullable PsiElement element) {


### PR DESCRIPTION
possible fix for #1081. (the provided example colorize correctly with  my changes)

For some reason the code ended up trying to resolve generics on classes that didn't have generics. i have added a check to prevent this never ending resolve logic.
