### PR TITLE
IDEA 2022.x support

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -6,6 +6,20 @@
       <module name="common_test" target="1.8" />
       <module name="hxcpp-debugger-protocol_main" target="1.8" />
       <module name="hxcpp-debugger-protocol_test" target="1.8" />
+      <module name="intellij-haxe" target="17" />
+      <module name="intellij-haxe.common" target="17" />
+      <module name="intellij-haxe.common.main" target="17" />
+      <module name="intellij-haxe.common.test" target="17" />
+      <module name="intellij-haxe.hxcpp-debugger-protocol" target="17" />
+      <module name="intellij-haxe.hxcpp-debugger-protocol.main" target="17" />
+      <module name="intellij-haxe.hxcpp-debugger-protocol.test" target="17" />
+      <module name="intellij-haxe.jps-plugin" target="17" />
+      <module name="intellij-haxe.jps-plugin.main" target="17" />
+      <module name="intellij-haxe.jps-plugin.test" target="17" />
+      <module name="intellij-haxe.main" target="17" />
+      <module name="intellij-haxe.templates" target="17" />
+      <module name="intellij-haxe.test" target="17" />
+      <module name="intellij-haxe.testTemplates" target="17" />
       <module name="intellij-haxe_main" target="1.8" />
       <module name="intellij-haxe_test" target="1.8" />
       <module name="jps-plugin_main" target="1.8" />

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="delegatedBuild" value="true" />
+        <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="JetBrains Runtime" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -13,8 +17,6 @@
             <option value="$PROJECT_DIR$/jps-plugin" />
           </set>
         </option>
-        <option name="resolveModulePerSourceSet" value="false" />
-        <option name="useAutoImport" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="JetBrains-jbsdk8u152b1343.26" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="IntelliJ IDEA IU-223.7571.182" project-jdk-type="IDEA JDK">
     <output url="file://$PROJECT_DIR$/classes" />
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -9,6 +9,19 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/hxcpp-debugger-protocol_main.iml" filepath="$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/hxcpp-debugger-protocol_main.iml" group="hxcpp-debugger-protocol" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/hxcpp-debugger-protocol_test.iml" filepath="$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/hxcpp-debugger-protocol_test.iml" group="hxcpp-debugger-protocol" />
       <module fileurl="file://$PROJECT_DIR$/intellij-haxe.iml" filepath="$PROJECT_DIR$/intellij-haxe.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/intellij-haxe.common.iml" filepath="$PROJECT_DIR$/.idea/modules/common/intellij-haxe.common.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/intellij-haxe.common.main.iml" filepath="$PROJECT_DIR$/.idea/modules/common/intellij-haxe.common.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/common/intellij-haxe.common.test.iml" filepath="$PROJECT_DIR$/.idea/modules/common/intellij-haxe.common.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/intellij-haxe.hxcpp-debugger-protocol.iml" filepath="$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/intellij-haxe.hxcpp-debugger-protocol.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/intellij-haxe.hxcpp-debugger-protocol.main.iml" filepath="$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/intellij-haxe.hxcpp-debugger-protocol.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/intellij-haxe.hxcpp-debugger-protocol.test.iml" filepath="$PROJECT_DIR$/.idea/modules/hxcpp-debugger-protocol/intellij-haxe.hxcpp-debugger-protocol.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/jps-plugin/intellij-haxe.jps-plugin.iml" filepath="$PROJECT_DIR$/.idea/modules/jps-plugin/intellij-haxe.jps-plugin.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/jps-plugin/intellij-haxe.jps-plugin.main.iml" filepath="$PROJECT_DIR$/.idea/modules/jps-plugin/intellij-haxe.jps-plugin.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/jps-plugin/intellij-haxe.jps-plugin.test.iml" filepath="$PROJECT_DIR$/.idea/modules/jps-plugin/intellij-haxe.jps-plugin.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/intellij-haxe.main.iml" filepath="$PROJECT_DIR$/.idea/modules/intellij-haxe.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/intellij-haxe.templates.iml" filepath="$PROJECT_DIR$/.idea/modules/intellij-haxe.templates.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/intellij-haxe.test.iml" filepath="$PROJECT_DIR$/.idea/modules/intellij-haxe.test.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/intellij-haxe.testTemplates.iml" filepath="$PROJECT_DIR$/.idea/modules/intellij-haxe.testTemplates.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/intellij-haxe_main.iml" filepath="$PROJECT_DIR$/.idea/modules/intellij-haxe_main.iml" group="intellij-haxe" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/intellij-haxe_test.iml" filepath="$PROJECT_DIR$/.idea/modules/intellij-haxe_test.iml" group="intellij-haxe" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/jps-plugin/jps-plugin.iml" filepath="$PROJECT_DIR$/.idea/modules/jps-plugin/jps-plugin.iml" group="jps-plugin" />

--- a/build.gradle
+++ b/build.gradle
@@ -19,11 +19,12 @@
 
 plugins {
     id 'de.undercouch.download' version '3.3.0'
-    id 'org.jetbrains.intellij' version '0.4.9'
-    id "org.jetbrains.grammarkit" version "2020.3.2"
+    id 'org.jetbrains.intellij' version '1.10.1'
+    id "org.jetbrains.grammarkit" version "2022.3"
     id "com.asarkar.gradle.build-time-tracker" version "2.0.4"
 }
 
+import org.jetbrains.intellij.DependenciesUtils
 import org.jetbrains.grammarkit.tasks.*
 
 if (!project.hasProperty('targetVersion')) {
@@ -97,25 +98,26 @@ allprojects {
         type = 'IU'
         version = "IU-${ideaVersion}"
         pluginName = "intellij-haxe-${ideaVersion}"
-        ideaDependencyCachePath "${ideaBaseDir}"
+        ideaDependencyCachePath = "${ideaBaseDir}"
         // Specify the sandbox so that Gradle doesn't try to make it relative to each sub-project.
-        sandboxDirectory "${project.rootDir}/build/idea-sandbox"
+        sandboxDir = "${project.rootDir}/build/idea-sandbox"
         // Don't let gradle fill in since/until, we fill them via patchCustomTags using the properties file.
-        updateSinceUntilBuild false
+        updateSinceUntilBuild = false
 
         // Include the "java" built-in plugin for 2019.2 and later builds.
         if (requiresJavaPlugin) {
             System.println("Including java plugin for version >= 2019.2")
-            plugins += 'java'  // 2019.2 + only.  Causes build errors on earlier versions.
+            plugins.add('java') // 2019.2 + only.  Causes build errors on earlier versions.
         }
         // Flex support was unbundled for version 2020.2.
         if (requiresFlexPlugin) {
             System.println("Including Flex plugin for version >= 2020.2")
             String versionWithMajor = ideaVersion.substring(0, 6);
             switch (versionWithMajor) {
-                case "2020.2" : plugins += 'com.intellij.flex:202.6397.59'; break
-                case "2020.3" : plugins += 'com.intellij.flex:203.5981.155'; break
-                case "2021.1" : plugins += 'com.intellij.flex:211.6693.111'; break
+                case "2020.2" : plugins.add('com.intellij.flex:202.6397.59'); break
+                case "2020.3" : plugins.add('com.intellij.flex:203.5981.155'); break
+                case "2021.1" : plugins.add('com.intellij.flex:211.6693.111'); break
+                case "2022.3.3" : plugins.add('com.intellij.flex:223.8617.9'); break
             }
 
         }
@@ -152,14 +154,15 @@ idea.module { generatedSourceDirs += file('gen') }
 
 
 dependencies {
+    implementation 'ch.qos.reload4j:reload4j:1.2.25'
 
-    compile files('gen') {
+    implementation files('gen') {
         builtBy 'generateSources'
     }
 
-    compile project(':common')
-    compile project(':jps-plugin')
-    compile project(':hxcpp-debugger-protocol')
+    implementation project(':common')
+    implementation project(':jps-plugin')
+    implementation project(':hxcpp-debugger-protocol')
 
     String flexPluginDir = "${ideaTargetDir}"
     if (requiresFlexPlugin) {
@@ -181,7 +184,7 @@ dependencies {
 
     testCompileOnly files(flexShared)
     testCompileOnly files(flexSupport)
-    testCompileOnly files("${ideaTargetDir}/lib/ openapi.jar")
+    testCompileOnly files("${ideaTargetDir}/lib/openapi.jar")
     testCompileOnly files("${ideaTargetDir}/lib/util.jar")
 
 }
@@ -189,7 +192,7 @@ dependencies {
 afterEvaluate {
     dependencies {
         if (requiresJavaPlugin) {
-            compile intellijPlugin('java') { include("${ideaTargetDir}/plugins/java/lib/jps-builders.jar") }
+            implementation DependenciesUtils.intellijPlugin(project, 'java') { include("${ideaTargetDir}/plugins/java/lib/jps-builders.jar") }
         }
     }
 }
@@ -241,10 +244,14 @@ processResources {
 }
 
 patchPluginXml {
+    def props = findSdkValuesAndProperties(file("${ideaTargetDir}/build.txt"))
+    sinceBuild = props.getProperty("plugin.installable.since")
+    untilBuild = props.getProperty("plugin.installable.until")
+
     pluginXmlFiles = [
-            'src/META-INF/plugin.xml',
-            'src/META-INF/debugger-support.xml',
-            'src/META-INF/flex-debugger-support.xml'
+            file('src/META-INF/plugin.xml'),
+            file('src/META-INF/debugger-support.xml'),
+            file('src/META-INF/flex-debugger-support.xml')
     ]
 }
 
@@ -320,13 +327,13 @@ task cleanGenerated(type: Delete, group: 'generate') {
 task generateHaxeParser(dependsOn: ':setupTools', type: JavaExec, group: 'generate') {
     workingDir = "${toolDir}"
     main '-jar'
-    args = ['grammar-kit.jar', "${generatedSrcDir}", "${grammarHaxe}"]
+    args = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.lang=ALL-UNNAMED', 'grammar-kit.jar', "${generatedSrcDir}", "${grammarHaxe}"]
 
     inputs.file "${grammarHaxe}"
     outputs.upToDateWhen { file("${generatedSrcDir}/com/intellij/plugins/haxe/lang").exists() }
 }
 
-task generateHaxeLexer(group: 'generate', dependsOn:'generateHaxeParser', type: GenerateLexer) {
+task generateHaxeLexer(group: 'generate', dependsOn:'generateHaxeParser', type: GenerateLexerTask) {
     source = "${haxeFlex}"
     targetDir = "${generatedSrcDir}/com/intellij/plugins/haxe/lang/lexer"
     targetClass = "com.intellij.plugins.haxe.lang.lexer._HaxeLexer"
@@ -335,7 +342,7 @@ task generateHaxeLexer(group: 'generate', dependsOn:'generateHaxeParser', type: 
     outputs.upToDateWhen { file("${generatedSrcDir}/com/intellij/plugins/haxe/lang/lexer/_HaxeLexer.java").exists() }
 
 }
-task generateHxmlLexer(group: 'generate', dependsOn:'generateHxmlParser', type: GenerateLexer) {
+task generateHxmlLexer(group: 'generate', dependsOn:'generateHxmlParser', type: GenerateLexerTask) {
     source = "${hxmlFlex}"
     targetDir = "${generatedSrcDir}/com/intellij/plugins/haxe/hxml/lexer"
     targetClass = "com.intellij.plugins.haxe.hxml.lexer.HXMLLexer"
@@ -344,7 +351,7 @@ task generateHxmlLexer(group: 'generate', dependsOn:'generateHxmlParser', type: 
     outputs.upToDateWhen { file("${generatedSrcDir}/com/intellij/plugins/haxe/hxml/lexer/HXMLLexer.java").exists() }
 
 }
-task generateMetadataLexer(group: 'generate', dependsOn:'generateMetadataParser', type: GenerateLexer) {
+task generateMetadataLexer(group: 'generate', dependsOn:'generateMetadataParser', type: GenerateLexerTask) {
     source = "${metadataFlex}"
     targetDir = "${generatedSrcDir}/com/intellij/plugins/haxe/metadata/lexer"
     targetClass = "com.intellij.plugins.haxe.metadata.lexer.MetadataLexer"
@@ -359,7 +366,7 @@ task generateMetadataLexer(group: 'generate', dependsOn:'generateMetadataParser'
 task generateHxmlParser(dependsOn: ':setupTools', type: JavaExec, group: 'generate') {
     workingDir = "${toolDir}"
     main '-jar'
-    args = ['grammar-kit.jar', "${generatedSrcDir}", "${grammarHxml}"]
+    args = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.lang=ALL-UNNAMED', 'grammar-kit.jar', "${generatedSrcDir}", "${grammarHxml}"]
 
     inputs.file "${grammarHxml}"
     outputs.upToDateWhen { file("${generatedSrcDir}/com/intellij/plugins/haxe/hxml").exists() }
@@ -368,7 +375,7 @@ task generateHxmlParser(dependsOn: ':setupTools', type: JavaExec, group: 'genera
 task generateMetadataParser(dependsOn: ':setupTools', type: JavaExec, group: 'generate') {
     workingDir = "${toolDir}"
     main '-jar'
-    args = ['grammar-kit.jar', "${generatedSrcDir}", "${grammarMetadata}"]
+    args = ['--add-opens=java.base/java.lang.reflect=ALL-UNNAMED', '--add-opens=java.base/java.util=ALL-UNNAMED', '--add-opens=java.base/java.lang=ALL-UNNAMED', 'grammar-kit.jar', "${generatedSrcDir}", "${grammarMetadata}"]
 
     inputs.file "${grammarMetadata}"
     outputs.upToDateWhen { file("${generatedSrcDir}/com/intellij/plugins/haxe/metadata").exists() }
@@ -430,6 +437,7 @@ Properties findSdkValuesAndProperties(File buildFile) {
     // Lookup table for properties files.  Add new versions here.
     def propertiesFile = ""
     switch (Integer.valueOf(codeLine, 10)) {
+        case 223: propertiesFile = "idea_v22.properties"; break
         case 211: propertiesFile = "idea_v21.properties"; break
         case 203: propertiesFile = "idea_v20.3.properties"; break
         case 202: propertiesFile = "idea_v20.properties"; break

--- a/build.gradle
+++ b/build.gradle
@@ -205,7 +205,7 @@ runIde {
     Properties props = System.getProperties()
     for (String pname : props.propertyNames()) {
         for (String prefix : prefixesToInclude) {
-            if (pname.startsWith(prefix)) {
+            if (pname.startsWith(prefix) && pname != 'idea.home.path') {
                 String pval = props.get(pname)
                 if (pval.contains(" ") && !pval.startsWith("'")) {
                     // Strings containing spaces require quoting.

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ allprojects {
                 case "2020.2" : plugins.add('com.intellij.flex:202.6397.59'); break
                 case "2020.3" : plugins.add('com.intellij.flex:203.5981.155'); break
                 case "2021.1" : plugins.add('com.intellij.flex:211.6693.111'); break
+                case "2022.3" : plugins.add('com.intellij.flex:223.7571.4'); break
                 case "2022.3.3" : plugins.add('com.intellij.flex:223.8617.9'); break
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,15 +25,14 @@ org.gradle.daemon.idletimeout=1
 # Avoid out of memmory on compile
 org.gradle.jvmargs=-Xms512m -Xmx512m
 
-defaultIdeaVersion=2020.2.1
-
+latest2022Version=2022.3.3
 latest2020Version=2020.2.1
 latest2019Version=2019.3.5
 latest2018Version=2018.3.6
 latest2017Version=2017.3.5
 latest2016Version=2016.3.8
 
-defaultIdeaVersion=2021.1
+defaultIdeaVersion=2022.3
 
 jarNametruncateMinor=true
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/intellij-haxe.iml
+++ b/intellij-haxe.iml
@@ -5,7 +5,6 @@
     <content url="file://$MODULE_DIR$">
       <excludeFolder url="file://$MODULE_DIR$/.gradle" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
-      <excludeFolder url="file://$MODULE_DIR$/out" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/jps-plugin/build.gradle
+++ b/jps-plugin/build.gradle
@@ -25,7 +25,7 @@ buildSearchableOptions.enabled = false
 sourceSets.main.java.srcDir "src"
 
 dependencies {
-  compile project(':common')
+  implementation project(':common')
 }
 
 processResources {

--- a/properties/idea_v22.properties
+++ b/properties/idea_v22.properties
@@ -1,0 +1,33 @@
+#
+# Copyright 2023 rosingrind
+#
+
+#
+# Properties for building against IDEA version 2022.
+#
+
+# Target version of IDEA that we typically build for.
+# This is appended to the name of the intellij-haxe-XXX jar file.
+idea.version=2022
+
+# Human-readable versions of IDEA that this build is compatible with.
+plugin.compatibility.description=IDEA 2022.x
+
+# ###################################################
+# IDEA build IDs that are compatible with this plugin.
+# ###################################################
+#
+# IDEA builds prior to this one will not install this plugin.
+#
+plugin.installable.since=223
+#
+# IDEA builds after this one will not install this plugin.
+#
+plugin.installable.until=223.*
+
+
+# ###################################################
+# Java compatibility.
+# ###################################################
+plugin.java.source.compatibility=17
+plugin.java.target.compatibility=17

--- a/src/META-INF/plugin.xml
+++ b/src/META-INF/plugin.xml
@@ -9,7 +9,7 @@
   ~ you may not use this file except in compliance with the License.
   ~ You may obtain a copy of the License at
   ~
-  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~ https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~ Unless required by applicable law or agreed to in writing, software
   ~ distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,7 +36,7 @@
           <table width="100%" cellpadding="5px" border="0" style="background-color:rgb(168,75,56);">
             <tr">
               <td align="right"><b>Documentation:</b></td>
-              <td align="left"><a style="color:white;" href="http://intellij-haxe.org">Project Web Site</a></td>
+              <td align="left"><a style="color:white;" href="https://intellij-haxe.org">Project Web Site</a></td>
             </tr>
             <tr>
               <td align="right"><b>Release Notes:</b></td>
@@ -48,11 +48,11 @@
             </tr>
             <tr>
               <td align="right"><b>Support:</b></td>
-              <td align="left"><a style="color:white;" href="http://community.haxe.org/">Community Discourse</a></td>
+              <td align="left"><a style="color:white;" href="https://community.haxe.org/">Community Discourse</a></td>
             </tr>
             <tr>
               <td align="right"><b>Enterprise Support:</b></td>
-              <td align="left"><a style="color:white;" href="http://bishtonsoftwaresolutions.com/">Bishton Software Solutions</a></td>
+              <td align="left"><a style="color:white;" href="https://bishtonsoftwaresolutions.com/">Bishton Software Solutions</a></td>
             </tr>
             <tr>
               <td align="right"><a href="https://www.patreon.com/EricBishton"><img border="0" height="30" width="30" src="https://c5.patreon.com/external/logo/downloads_logomark_color_on_navy.png"></a></td>
@@ -80,7 +80,7 @@
   <depends optional="true" config-file="debugger-support.xml">com.intellij.modules.ultimate</depends>
 
   <!-- Leave the '999' at the start of unreleased version numbers so that it's always newer than any released version. -->
-  <version>999 Unreleased Post 1.3.1@plugin.dev.version@ for @plugin.compatibility.description@</version>
+  <version>DEV @plugin.dev.version@ for @plugin.compatibility.description@</version>
   <change-notes>
   <![CDATA[
       <p>Unreleased changes</p>
@@ -481,7 +481,7 @@
         </li>
         <li>Use implicit classpath entries during classpath operations. (e.g. haxe/std)</li>
         <li>Remove "statics of XXX" from the debugger variable window pane.  (The Haxe debugger
-            at http://github.com/tivo/hxcpp-debugger has been updated to show statics
+            at https://github.com/tivo/hxcpp-debugger has been updated to show statics
             as part of the object tree for objects in view.
         </li>
         <li>Remove error embellishments before displaying errors in the debugger variable pane.</li>

--- a/src/common/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
+++ b/src/common/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
@@ -25,7 +25,6 @@ import com.intellij.execution.configurations.RunConfiguration;
 import com.intellij.execution.configurations.RunConfigurationModule;
 import com.intellij.execution.executors.DefaultDebugExecutor;
 import com.intellij.openapi.compiler.*;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleType;
 import com.intellij.openapi.module.ModuleUtil;
@@ -48,6 +47,7 @@ import com.intellij.plugins.haxe.module.HaxeModuleSettingsBase;
 import com.intellij.plugins.haxe.runner.debugger.HaxeDebugRunner;
 import com.intellij.plugins.haxe.tests.runner.HaxeTestsConfiguration;
 import com.intellij.plugins.haxe.util.HaxeCommonCompilerUtil;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeSdkUtilBase;
 import com.intellij.util.PathUtil;
 import org.jetbrains.annotations.NotNull;
@@ -58,7 +58,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class HaxeCompiler implements FileProcessingCompiler {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.compilation.HaxeCompiler");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.compilation.HaxeCompiler");
 
   /*
   // flag to indicate whether a module needs to be built

--- a/src/common/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
+++ b/src/common/com/intellij/plugins/haxe/compilation/HaxeCompiler.java
@@ -187,7 +187,7 @@ public class HaxeCompiler implements FileProcessingCompiler {
   }
 
   public static HaxeCommonCompilerUtil.CompilationContext createDummyCompilationContext(final Module module) {
-    DummyCompileContext context = new DummyCompileContext() {
+    DummyCompileContext context = new DummyCompileContext(module.getProject()) {
       @Override
       public Project getProject() {
         return module.getProject();

--- a/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
+++ b/src/common/com/intellij/plugins/haxe/config/sdk/HaxeSdkUtil.java
@@ -18,13 +18,13 @@
  */
 package com.intellij.plugins.haxe.config.sdk;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.projectRoots.SdkModificator;
 import com.intellij.openapi.roots.JavadocOrderRootType;
 import com.intellij.openapi.roots.OrderRootType;
 import com.intellij.openapi.util.SystemInfo;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeFileUtil;
 import com.intellij.plugins.haxe.util.HaxeProcessUtil;
 import com.intellij.plugins.haxe.util.HaxeSdkUtilBase;
@@ -39,7 +39,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class HaxeSdkUtil extends HaxeSdkUtilBase {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil");
   private static final Pattern VERSION_MATCHER = Pattern.compile("(\\d+(\\.\\d+)+)");
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/editor/smartEnter/HaxeSmartEnterProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/editor/smartEnter/HaxeSmartEnterProcessor.java
@@ -19,10 +19,10 @@
 package com.intellij.plugins.haxe.editor.smartEnter;
 
 import com.intellij.codeInsight.editorActions.smartEnter.SmartEnterProcessor;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.lang.psi.HaxeFile;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.util.IncorrectOperationException;
@@ -35,7 +35,7 @@ import java.util.List;
  * Created by as3boyan on 06.10.14.
  */
 public class HaxeSmartEnterProcessor extends SmartEnterProcessor {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.editor.smartEnter.HaxeSmartEnterProcessor");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.editor.smartEnter.HaxeSmartEnterProcessor");
 
   private static final Fixer[] ourFixers;
 

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxeClasspath.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxeClasspath.java
@@ -18,7 +18,7 @@
  */
 package com.intellij.plugins.haxe.haxelib;
 
-import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
@@ -30,7 +30,7 @@ import java.util.*;
  */
 public class HaxeClasspath {
 
-  static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeClasspath");
+  static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeClasspath");
 
   /**
    * An immutable empty classpath that can be re-used.

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxeLibraryList.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxeLibraryList.java
@@ -18,10 +18,10 @@
  */
 package com.intellij.plugins.haxe.haxelib;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.ModuleRootManager;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -33,7 +33,7 @@ import java.util.*;
  */
 public class HaxeLibraryList {
 
-  static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeLibraryList");
+  static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeLibraryList");
 
   /**
    * Minimum size to use for new lists.

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibClasspathUtils.java
@@ -21,7 +21,6 @@ package com.intellij.plugins.haxe.haxelib;
 
 import com.google.common.base.Joiner;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
@@ -40,6 +39,7 @@ import com.intellij.plugins.haxe.hxml.HXMLFileType;
 import com.intellij.plugins.haxe.hxml.psi.HXMLClasspath;
 import com.intellij.plugins.haxe.hxml.psi.HXMLPsiImplUtil;
 import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeSdkUtilBase;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
@@ -61,7 +61,7 @@ import java.util.*;
  */
 public class HaxelibClasspathUtils {
 
-  static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibClasspathUtils");
+  static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibClasspathUtils");
   static {
     LOG.setLevel(Level.DEBUG);
   }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibItem.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibItem.java
@@ -18,7 +18,7 @@
  */
 package com.intellij.plugins.haxe.haxelib;
 
-import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class HaxelibItem extends HaxeClasspathEntry {
 
-  Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibItem");
+  HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibItem");
 
   public static final List<HaxelibItem> EMPTY_LIST = new ArrayList<HaxelibItem>(0);
 

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCache.java
@@ -18,8 +18,8 @@
  */
 package com.intellij.plugins.haxe.haxelib;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeDebugTimeLog;
 import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
  */
 public final class HaxelibLibraryCache {
 
-  static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeLibraryManager");
+  static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeLibraryManager");
   {
     LOG.setLevel(Level.DEBUG);
   }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCacheManager.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibLibraryCacheManager.java
@@ -17,9 +17,9 @@
  */
 package com.intellij.plugins.haxe.haxelib;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -42,7 +42,7 @@ import java.util.Hashtable;
  */
 public class HaxelibLibraryCacheManager {
 
-  static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeLibraryManager");
+  static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxeLibraryManager");
   static {
     LOG.setLevel(Level.DEBUG);
   }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibModuleManager.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibModuleManager.java
@@ -19,9 +19,9 @@ package com.intellij.plugins.haxe.haxelib;
 
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class HaxelibModuleManager implements com.intellij.openapi.module.ModuleComponent {
 
-  static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibManager");
+  static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibManager");
   static {
     LOG.setLevel(Level.DEBUG);
   }

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibProjectUpdater.java
@@ -21,7 +21,6 @@ package com.intellij.plugins.haxe.haxelib;
 import com.intellij.ide.highlighter.XmlFileType;
 import com.intellij.openapi.application.Application;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
 import com.intellij.openapi.progress.PerformInBackgroundOption;
@@ -46,10 +45,7 @@ import com.intellij.plugins.haxe.hxml.model.HXMLProjectModel;
 import com.intellij.plugins.haxe.ide.module.HaxeModuleSettings;
 import com.intellij.plugins.haxe.ide.module.HaxeModuleType;
 import com.intellij.plugins.haxe.nmml.NMMLFileType;
-import com.intellij.plugins.haxe.util.HaxeDebugTimeLog;
-import com.intellij.plugins.haxe.util.HaxeDebugUtil;
-import com.intellij.plugins.haxe.util.HaxeFileUtil;
-import com.intellij.plugins.haxe.util.Lambda;
+import com.intellij.plugins.haxe.util.*;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
 import com.intellij.psi.xml.XmlFile;
@@ -82,7 +78,7 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public class HaxelibProjectUpdater {
 
-  static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibManager");
+  static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.haxelib.HaxelibManager");
 
   {
     LOG.setLevel(Level.DEBUG);
@@ -425,7 +421,7 @@ public class HaxelibProjectUpdater {
       list.iterate(new HaxeLibraryList.Lambda() {
         @Override
         public boolean processEntry(HaxeLibraryReference entry) {
-          LOG.assertTrue(entry.isManaged(), msg);
+          LOG.assertLog(entry.isManaged(), msg);
           return true;
         }
       });
@@ -943,7 +939,7 @@ public class HaxelibProjectUpdater {
       toRemove.iterate(new HaxeLibraryList.Lambda() {
         @Override
         public boolean processEntry(HaxeLibraryReference entry) {
-          LOG.assertTrue(entry.isManaged(), "Attempting to automatically remove a library that was not marked as managed.");
+          LOG.assertLog(entry.isManaged(), "Attempting to automatically remove a library that was not marked as managed.");
           return true;
         }
       });
@@ -952,7 +948,7 @@ public class HaxelibProjectUpdater {
       toAdd.iterate(new HaxeLibraryList.Lambda() {
         @Override
         public boolean processEntry(HaxeLibraryReference entry) {
-          LOG.assertTrue(entry.isManaged(), "Attempting to automatically add a library that is not marked as managed.");
+          LOG.assertLog(entry.isManaged(), "Attempting to automatically add a library that is not marked as managed.");
           return true;
         }
       });
@@ -975,7 +971,7 @@ public class HaxelibProjectUpdater {
             public boolean processEntry(HaxeLibraryReference entry) {
               Library library = projectModifiableModel.getLibraryByName(
                 entry.getName());
-              LOG.assertTrue(null != library, "Library " + entry.getName() + " was not found in the project and will not be removed.");
+              LOG.assertLog(null != library, "Library " + entry.getName() + " was not found in the project and will not be removed.");
               if (null != library) {
                 projectModifiableModel.removeLibrary(library);
                 timeLog.stamp("Removed library " + entry.getName());
@@ -1298,7 +1294,7 @@ public class HaxelibProjectUpdater {
         refs = --myReferenceCount;
       }
       // XXX: Maybe we don't need an assertion for this.
-      LOG.assertTrue(refs >= 0);
+      LOG.assertLog(refs >= 0, "Assertion failed");
 
       return refs;
     }
@@ -1495,15 +1491,15 @@ public class HaxelibProjectUpdater {
      */
     private void queueNextProject() {
       synchronized (updateSyncToken) {
-        LOG.assertTrue(null == updatingProject);
+        LOG.assertLog(null == updatingProject, "Assertion failed");
 
         // Get the next project from the queue. We're done if there's
         // nothing left.
         updatingProject = queue.poll();  // null if empty.
         if (updatingProject == null) return;
 
-        LOG.assertTrue(updatingProject.isDirty());
-        LOG.assertTrue(!updatingProject.isUpdating());
+        LOG.assertLog(updatingProject.isDirty(), "Assertion failed");
+        LOG.assertLog(!updatingProject.isUpdating(), "Assertion failed");
 
         updatingProject.setUpdating(true);
       }
@@ -1578,8 +1574,8 @@ public class HaxelibProjectUpdater {
      */
     private void finishUpdate(ProjectTracker up) {
       synchronized (updateSyncToken) {
-        LOG.assertTrue(null != updatingProject);
-        LOG.assertTrue(up.equals(updatingProject));
+        LOG.assertLog(null != updatingProject, "Assertion failed");
+        LOG.assertLog(up.equals(updatingProject), "Assertion failed");
 
         updatingProject.setUpdating(false);
         updatingProject.setDirty(false);

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibSdkUtils.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibSdkUtils.java
@@ -18,7 +18,6 @@
  */
 package com.intellij.plugins.haxe.haxelib;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
@@ -26,6 +25,7 @@ import com.intellij.openapi.projectRoots.impl.ProjectJdkImpl;
 import com.intellij.openapi.roots.ModuleRootManager;
 import com.intellij.openapi.roots.ProjectRootManager;
 import com.intellij.plugins.haxe.config.sdk.HaxeSdkType;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -35,7 +35,7 @@ public class HaxelibSdkUtils {
 
   // TODO: Move these routines into HaxeSdkUtil and kill this class.
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugin.haxe.haxelib.HaxelibSdkUtils");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugin.haxe.haxelib.HaxelibSdkUtils");
 
   /**
    * An SDK that can be used/returned when project lookup fails.

--- a/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
+++ b/src/common/com/intellij/plugins/haxe/haxelib/HaxelibUtil.java
@@ -20,8 +20,6 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.projectRoots.Sdk;
 import com.intellij.openapi.roots.*;
-import com.intellij.openapi.roots.impl.ModuleRootManagerImpl;
-import com.intellij.openapi.roots.impl.RootModelBase;
 import com.intellij.openapi.roots.impl.libraries.ProjectLibraryTable;
 import com.intellij.openapi.roots.libraries.Library;
 import com.intellij.openapi.roots.libraries.LibraryTable;
@@ -214,11 +212,8 @@ public class HaxelibUtil {
     if (null == rootManager) return new HaxeLibraryList(module);
 
     final HaxeLibraryList moduleLibs = new HaxeLibraryList(module);
-    if (rootManager instanceof ModuleRootManagerImpl) {
-      ModuleRootManagerImpl rootManagerImpl = (ModuleRootManagerImpl)rootManager;
-
-      RootModelBase modelBase = rootManagerImpl.getRootModel(); // Can't fail.
-      OrderEnumerator entries = modelBase.orderEntries();       // Can't fail.
+    if (rootManager instanceof ModuleRootModel) {
+      OrderEnumerator entries = rootManager.orderEntries();       // Can't fail.
 
       entries.forEachLibrary(new Processor<Library>() {
         @Override

--- a/src/common/com/intellij/plugins/haxe/ide/HXMLHaxelibCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HXMLHaxelibCompletionContributor.java
@@ -19,7 +19,6 @@ package com.intellij.plugins.haxe.ide;
 
 import com.intellij.codeInsight.completion.*;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.plugins.haxe.haxelib.HaxelibCache;
 import com.intellij.plugins.haxe.hxml.HXMLLanguage;
@@ -27,6 +26,7 @@ import com.intellij.plugins.haxe.hxml.psi.HXMLLib;
 import com.intellij.plugins.haxe.hxml.psi.HXMLTokenType;
 import com.intellij.plugins.haxe.hxml.psi.HXMLTypes;
 import com.intellij.plugins.haxe.hxml.psi.HXMLValue;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -42,7 +42,7 @@ public class HXMLHaxelibCompletionContributor extends CompletionContributor {
   protected static List<String> availableHaxelibs = null;
   protected static List<String> localHaxelibs = null;
 
-  public static final Logger LOGGER = Logger.getInstance("com.intellij.plugins.haxe.ide.HXMLHaxelibCompletionProvider");
+  public static final HaxeDebugLogger LOGGER = HaxeDebugLogger.getInstance("com.intellij.plugins.haxe.ide.HXMLHaxelibCompletionProvider");
 
   public HXMLHaxelibCompletionContributor() {
     HaxelibCache haxelibCache = HaxelibCache.getInstance();

--- a/src/common/com/intellij/plugins/haxe/ide/HaxeFindUsagesProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeFindUsagesProvider.java
@@ -20,11 +20,10 @@ package com.intellij.plugins.haxe.ide;
 
 import com.intellij.lang.cacheBuilder.WordsScanner;
 import com.intellij.lang.findUsages.FindUsagesProvider;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.HaxeComponentType;
 import com.intellij.plugins.haxe.lang.psi.HaxeClass;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
-import org.apache.log4j.Level;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -32,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class HaxeFindUsagesProvider implements FindUsagesProvider {
 
-  final static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.HaxeFindUsagesProvider");
+  final static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.HaxeFindUsagesProvider");
 
   @Override
   public WordsScanner getWordsScanner() {

--- a/src/common/com/intellij/plugins/haxe/ide/HaxeLineMarkerProviderNS.java
+++ b/src/common/com/intellij/plugins/haxe/ide/HaxeLineMarkerProviderNS.java
@@ -50,6 +50,7 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Supplier;
 
 /**
  * Worker/implementation class for {@link HaxeLineMarkerProvider}.
@@ -128,6 +129,7 @@ public abstract class HaxeLineMarkerProviderNS implements LineMarkerProvider {
                               HaxeResolveUtil.getDeclarationTypes(methodDeclaration.getMethodModifierList()).
                                 contains(HaxeTokenTypes.KOVERRIDE);
     final Icon icon = overrides ? AllIcons.Gutter.OverridingMethod : AllIcons.Gutter.ImplementingMethod;
+    Supplier<String> accessibleNameProvider = () -> overrides ? "Overriding Method" : "Implementing Method";
     if (null == element) {
       return null;
     }
@@ -135,7 +137,6 @@ public abstract class HaxeLineMarkerProviderNS implements LineMarkerProvider {
       element,
       element.getTextRange(),
       icon,
-      Pass.UPDATE_ALL,
       new Function<PsiElement, String>() {
         @Override
         public String fun(PsiElement element) {
@@ -158,7 +159,8 @@ public abstract class HaxeLineMarkerProviderNS implements LineMarkerProvider {
             new DefaultPsiElementCellRenderer());
         }
       },
-      GutterIconRenderer.Alignment.LEFT
+      GutterIconRenderer.Alignment.LEFT,
+      accessibleNameProvider
     );
   }
 
@@ -177,11 +179,11 @@ public abstract class HaxeLineMarkerProviderNS implements LineMarkerProvider {
       return null;
     }
     final PsiElement element = componentName.getIdentifier().getFirstChild();
+    Supplier<String> accessibleNameProvider = () -> isInterface ? "Implemented Method" : "Overriden Method";
     return new LineMarkerInfo<>(
       element,
       element.getTextRange(),
       isInterface ? AllIcons.Gutter.ImplementedMethod : AllIcons.Gutter.OverridenMethod,
-      Pass.UPDATE_ALL,
       new Function<PsiElement, String>() {
         @Override
         public String fun(PsiElement element) {
@@ -204,7 +206,8 @@ public abstract class HaxeLineMarkerProviderNS implements LineMarkerProvider {
           );
         }
       },
-      GutterIconRenderer.Alignment.RIGHT
+      GutterIconRenderer.Alignment.RIGHT,
+      accessibleNameProvider
     );
   }
 
@@ -216,13 +219,13 @@ public abstract class HaxeLineMarkerProviderNS implements LineMarkerProvider {
       return null;
     }
     final PsiElement element = componentName.getIdentifier().getFirstChild();
+    Supplier<String> accessibleNameProvider = () -> componentWithDeclarationList instanceof HaxeInterfaceDeclaration ? "Implemented Method" : "Overriden Method";
     return new LineMarkerInfo<>(
       element,
       element.getTextRange(),
       componentWithDeclarationList instanceof HaxeInterfaceDeclaration
       ? AllIcons.Gutter.ImplementedMethod
       : AllIcons.Gutter.OverridenMethod,
-      Pass.UPDATE_ALL,
       item -> DaemonBundle.message("method.is.implemented.too.many"),
       new GutterIconNavigationHandler<PsiElement>() {
         @Override
@@ -235,7 +238,8 @@ public abstract class HaxeLineMarkerProviderNS implements LineMarkerProvider {
           );
         }
       },
-      GutterIconRenderer.Alignment.RIGHT
+      GutterIconRenderer.Alignment.RIGHT,
+      accessibleNameProvider
     );
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/XmlHaxelibCompletionContributor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/XmlHaxelibCompletionContributor.java
@@ -20,10 +20,10 @@ package com.intellij.plugins.haxe.ide;
 import com.intellij.codeInsight.completion.*;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.lang.xml.XMLLanguage;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.patterns.PlatformPatterns;
 import com.intellij.patterns.XmlPatterns;
 import com.intellij.plugins.haxe.haxelib.HaxelibCache;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -37,7 +37,7 @@ public class XmlHaxelibCompletionContributor extends CompletionContributor {
   protected static List<String> availableHaxelibs = null;
   protected static List<String> localHaxelibs = null;
 
-  public static final Logger LOGGER = Logger.getInstance("com.intellij.plugins.haxe.ide.XmlHaxelibCompletionProvider");
+  public static final HaxeDebugLogger LOGGER = HaxeDebugLogger.getInstance("com.intellij.plugins.haxe.ide.XmlHaxelibCompletionProvider");
 
   public XmlHaxelibCompletionContributor() {
     HaxelibCache haxelibCache = HaxelibCache.getInstance();

--- a/src/common/com/intellij/plugins/haxe/ide/actions/CreateClassAction.java
+++ b/src/common/com/intellij/plugins/haxe/ide/actions/CreateClassAction.java
@@ -48,7 +48,7 @@ public class CreateClassAction extends CreateTemplateInPackageAction<PsiFile> {
 
   private static Set<JavaSourceRootType> SOURCES;
   static {
-    SOURCES = ContainerUtilRt.newHashSet(JavaSourceRootType.SOURCE, JavaSourceRootType.TEST_SOURCE);
+    SOURCES = ContainerUtilRt.newLinkedHashSet(JavaSourceRootType.SOURCE, JavaSourceRootType.TEST_SOURCE);
   }
 
   public CreateClassAction() {

--- a/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeAnnotationHolder.java
+++ b/src/common/com/intellij/plugins/haxe/ide/annotator/HaxeAnnotationHolder.java
@@ -22,11 +22,11 @@ import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.AnnotationSession;
 import com.intellij.lang.annotation.HighlightSeverity;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Comparing;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.xml.util.XmlStringUtil;
@@ -42,7 +42,7 @@ import java.util.*;
  *
  */
 public class HaxeAnnotationHolder implements AnnotationHolder {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.annotator.HaxeAnnotationHolder");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.annotator.HaxeAnnotationHolder");
   private static final Key<HashMap<Integer, Annotation>> HAXE_ANNOTATION_KEY = new Key<>("HaxeAnnotationsKey");
   private final AnnotationHolderImpl myInternalHolder;
 
@@ -228,7 +228,7 @@ public class HaxeAnnotationHolder implements AnnotationHolder {
     if (node == null) return;
     PsiFile myFile = getCurrentAnnotationSession().getFile();
     PsiFile containingFile = node.getContainingFile();
-    LOG.assertTrue(containingFile != null, node);
+    LOG.assertLog(containingFile != null, node.getText());
     VirtualFile containingVFile = containingFile.getVirtualFile();
     VirtualFile myVFile = myFile.getVirtualFile();
     if (!Comparing.equal(containingVFile, myVFile)) {

--- a/src/common/com/intellij/plugins/haxe/ide/editor/HaxeTypedHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/editor/HaxeTypedHandler.java
@@ -19,7 +19,7 @@ package com.intellij.plugins.haxe.ide.editor;
 import com.intellij.codeInsight.AutoPopupController;
 import com.intellij.codeInsight.CodeInsightSettings;
 import com.intellij.codeInsight.completion.CompletionType;
-import com.intellij.codeInsight.editorActions.JavaTypedHandler;
+import com.intellij.codeInsight.editorActions.TypedHandlerUtil;
 import com.intellij.codeInsight.editorActions.TypedHandlerDelegate;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileTypes.FileType;
@@ -58,7 +58,7 @@ public class HaxeTypedHandler extends TypedHandlerDelegate {
     }
     if (c == '>') {
       if (CodeInsightSettings.getInstance().AUTOINSERT_PAIR_BRACKET &&
-          JavaTypedHandler.handleJavaGT(editor, HaxeTokenTypes.OLESS, HaxeTokenTypes.OGREATER, INVALID_INSIDE_REFERENCE)) {
+          TypedHandlerUtil.handleGenericGT(editor, HaxeTokenTypes.OLESS, HaxeTokenTypes.OGREATER, INVALID_INSIDE_REFERENCE)) {
         return Result.STOP;
       }
     }

--- a/src/common/com/intellij/plugins/haxe/ide/formatter/HaxeSpacingProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/formatter/HaxeSpacingProcessor.java
@@ -22,12 +22,12 @@ package com.intellij.plugins.haxe.ide.formatter;
 import com.intellij.formatting.Block;
 import com.intellij.formatting.Spacing;
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.plugins.haxe.build.FieldWrapper;
 import com.intellij.plugins.haxe.build.IdeaTarget;
 import com.intellij.plugins.haxe.ide.formatter.settings.HaxeCodeStyleSettings;
 import com.intellij.plugins.haxe.metadata.util.HaxeMetadataUtils;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.codeStyle.CommonCodeStyleSettings;
 import com.intellij.psi.formatter.common.AbstractBlock;
@@ -43,7 +43,7 @@ import static java.lang.Integer.max;
  * @author: Fedor.Korotkov
  */
 public class HaxeSpacingProcessor {
-  private final static Logger LOG = Logger.getInstance("#HaxeSpacingProcessor");
+  private final static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#HaxeSpacingProcessor");
   private final ASTNode myNode;
   private final CommonCodeStyleSettings mySettings;
   private final HaxeCodeStyleSettings myHaxeCodeStyleSettings;

--- a/src/common/com/intellij/plugins/haxe/ide/generation/BaseHaxeGenerateHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/generation/BaseHaxeGenerateHandler.java
@@ -22,7 +22,6 @@ import com.intellij.ide.util.MemberChooser;
 import com.intellij.lang.LanguageCodeInsightActionHandler;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.ide.HaxeNamedElementNode;
@@ -30,6 +29,7 @@ import com.intellij.plugins.haxe.lang.psi.HaxeClass;
 import com.intellij.plugins.haxe.lang.psi.HaxeClassDeclaration;
 import com.intellij.plugins.haxe.lang.psi.HaxeFile;
 import com.intellij.plugins.haxe.lang.psi.HaxeNamedComponent;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.util.PsiTreeUtil;
 import com.intellij.util.Function;
@@ -102,7 +102,7 @@ public abstract class BaseHaxeGenerateHandler implements LanguageCodeInsightActi
               createMethodsFix.invoke(project, editor, file);
             }
             catch (IncorrectOperationException ex) {
-              Logger.getInstance(getClass().getName()).error(ex);
+              HaxeDebugLogger.getInstance(getClass().getName()).error(ex);
             }
           }
         });

--- a/src/common/com/intellij/plugins/haxe/ide/generation/HaxeOverrideMethodHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/generation/HaxeOverrideMethodHandler.java
@@ -18,13 +18,13 @@
  */
 package com.intellij.plugins.haxe.ide.generation;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.HaxeBundle;
 import com.intellij.plugins.haxe.lang.psi.HaxeClass;
 import com.intellij.plugins.haxe.lang.psi.HaxeNamedComponent;
 import com.intellij.plugins.haxe.lang.psi.HaxePsiModifier;
 import com.intellij.plugins.haxe.model.HaxeClassModel;
 import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.apache.log4j.Level;
 
 import java.util.List;
@@ -34,7 +34,7 @@ import java.util.List;
  */
 public class HaxeOverrideMethodHandler extends BaseHaxeGenerateHandler {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.generation.HaxeOverrideMethodHandler");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.generation.HaxeOverrideMethodHandler");
   {
     LOG.info("Loaded HaxeOverrideMethodHandler");
     LOG.setLevel(Level.DEBUG);

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/HaxeHierarchyTimeoutHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/HaxeHierarchyTimeoutHandler.java
@@ -18,11 +18,11 @@
 package com.intellij.plugins.haxe.ide.hierarchy;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeDebugTimeLog;
 import org.apache.log4j.Level;
 import org.jetbrains.annotations.Nullable;
@@ -43,7 +43,7 @@ import java.util.TimerTask;
 final public class HaxeHierarchyTimeoutHandler {
 
   private static final boolean DEBUG = false;
-  private static final Logger LOG = Logger.getInstance("#com.intellij.ide.hierarchy.HaxeHierarchyTimeoutHandler");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.ide.hierarchy.HaxeHierarchyTimeoutHandler");
 
   static
   {

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/HaxeHierarchyUtils.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/HaxeHierarchyUtils.java
@@ -22,12 +22,12 @@ import com.intellij.codeInsight.TargetElementUtil;
 import com.intellij.codeInsight.TargetElementUtilBase;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass;
 import com.intellij.plugins.haxe.lang.psi.impl.AnonymousHaxeTypeImpl;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.source.resolve.reference.impl.PsiMultiReference;
 import com.intellij.psi.impl.source.tree.LeafPsiElement;
@@ -48,7 +48,7 @@ import java.util.List;
  * A set of utility functions that support the HierarchyProviders.
  */
 public class HaxeHierarchyUtils {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.ide.hierarchy.HaxeHierarchyUtils");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.ide.hierarchy.HaxeHierarchyUtils");
 
   //static
   //{

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallHierarchyBrowser.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallHierarchyBrowser.java
@@ -19,8 +19,8 @@ package com.intellij.plugins.haxe.ide.hierarchy.call;
 
 import com.intellij.ide.hierarchy.HierarchyTreeStructure;
 import com.intellij.ide.hierarchy.call.CallHierarchyBrowser;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class HaxeCallHierarchyBrowser extends CallHierarchyBrowser {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.ide.hierarchy.type.HaxeCallHierarchyBrowser");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.ide.hierarchy.type.HaxeCallHierarchyBrowser");
 
   HaxeCallHierarchyBrowser(Project project, PsiMethod method) { super(project, method); }
 

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallHierarchyProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallHierarchyProvider.java
@@ -22,9 +22,9 @@ import com.intellij.ide.hierarchy.HierarchyBrowser;
 import com.intellij.ide.hierarchy.HierarchyProvider;
 import com.intellij.ide.hierarchy.call.CallHierarchyBrowser;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.ide.hierarchy.HaxeHierarchyUtils;
 import com.intellij.plugins.haxe.lang.psi.HaxeMethod;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import org.apache.log4j.Level;
@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
  * Created by ebishton on 9/3/14.
  */
 public class HaxeCallHierarchyProvider implements HierarchyProvider {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.ide.hierarchy.type.HaxeCallHierarchyProvider");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.ide.hierarchy.type.HaxeCallHierarchyProvider");
 
   static {
     LOG.info("Loaded HaxeCallHierarchyProvider");

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallReferenceProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallReferenceProcessor.java
@@ -21,12 +21,12 @@ import com.intellij.ide.hierarchy.call.CallHierarchyNodeDescriptor;
 import com.intellij.ide.hierarchy.call.CallReferenceProcessor;
 import com.intellij.ide.hierarchy.call.JavaCallHierarchyData;
 import com.intellij.ide.util.treeView.NodeDescriptor;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.ide.hierarchy.HaxeHierarchyTimeoutHandler;
 import com.intellij.plugins.haxe.lang.psi.HaxeNewExpression;
 import com.intellij.plugins.haxe.lang.psi.HaxeReferenceExpression;
 import com.intellij.plugins.haxe.lang.psi.HaxeSuperExpression;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.util.PsiUtil;
 import com.intellij.psi.util.TypeConversionUtil;
@@ -39,7 +39,7 @@ import java.util.Set;
  * Created by ebishton on 1/9/15.  Lifted from JavaCallReferenceProcessor.
  */
 public class HaxeCallReferenceProcessor implements CallReferenceProcessor {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.call.HaxeCallReferenceProcessor");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.call.HaxeCallReferenceProcessor");
 
   public static class CallData extends JavaCallHierarchyData {
     HaxeHierarchyTimeoutHandler myTimeoutHandler;

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallReferenceProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallReferenceProcessor.java
@@ -50,7 +50,7 @@ public class HaxeCallReferenceProcessor implements CallReferenceProcessor {
                                  PsiMethod method,
                                  Set<PsiMethod> methodsToFind,
                                  NodeDescriptor nodeDescriptor,
-                                 Map<PsiMember, NodeDescriptor> resultMap,
+                                 Map<PsiMember, NodeDescriptor<?>> resultMap,
                                  Project project,
                                  HaxeHierarchyTimeoutHandler timeoutHandler) {
       super(originalClass, methodToFind, originalType, method, methodsToFind, nodeDescriptor, resultMap, project);
@@ -74,10 +74,10 @@ public class HaxeCallReferenceProcessor implements CallReferenceProcessor {
 
     PsiClass originalClass = data.getOriginalClass();
     PsiMethod method = data.getMethod();
-    Set<PsiMethod> methodsToFind = data.getMethodsToFind();
+    Set<? extends PsiMethod> methodsToFind = data.getMethodsToFind();
     PsiMethod methodToFind = data.getMethodToFind();
     PsiClassType originalType = data.getOriginalType();
-    Map<PsiMember, NodeDescriptor> methodToDescriptorMap = data.getResultMap();
+    Map<PsiMember, NodeDescriptor<?>> methodToDescriptorMap = data.getResultMap();
     Project myProject = data.getProject();
     HaxeHierarchyTimeoutHandler timeoutHandler = data.getTimeoutHandler();
 

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallerMethodsTreeStructure.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallerMethodsTreeStructure.java
@@ -23,10 +23,10 @@ import com.intellij.ide.hierarchy.call.CallHierarchyNodeDescriptor;
 import com.intellij.ide.hierarchy.call.CallReferenceProcessor;
 import com.intellij.ide.util.treeView.NodeDescriptor;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.*;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.ide.hierarchy.HaxeHierarchyTimeoutHandler;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.search.SearchScope;
 import com.intellij.psi.search.searches.MethodReferencesSearch;
@@ -45,7 +45,7 @@ import java.util.*;
 public class HaxeCallerMethodsTreeStructure extends HierarchyTreeStructure {
 
   private static final boolean DEBUG = false;
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.HaxeCallerMethodsTreeStructure");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.HaxeCallerMethodsTreeStructure");
   static {
     if (DEBUG) {
       LOG.setLevel(Level.DEBUG);

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallerMethodsTreeStructure.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/call/HaxeCallerMethodsTreeStructure.java
@@ -141,7 +141,7 @@ public class HaxeCallerMethodsTreeStructure extends HierarchyTreeStructure {
       ContainerUtil.addAll(methodsToFind, method.findDeepestSuperMethods());
       // timeLog.stampAndEcho("beginning to walk " + methodsToFind.size() + " methods");
 
-      final Map<PsiMember, NodeDescriptor> methodToDescriptorMap = new HashMap<PsiMember, NodeDescriptor>();
+      final Map<PsiMember, NodeDescriptor<?>> methodToDescriptorMap = new HashMap<PsiMember, NodeDescriptor<?>>();
       for (final PsiMethod methodToFind : methodsToFind) {
         final HaxeCallReferenceProcessor.CallData data =
           new HaxeCallReferenceProcessor.CallData(originalClass, methodToFind, originalType, method, methodsToFind,

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyBrowser.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyBrowser.java
@@ -39,7 +39,7 @@ public class HaxeMethodHierarchyBrowser extends MethodHierarchyBrowser {
 
   @Override
   protected HierarchyTreeStructure createHierarchyTreeStructure(@NotNull String typeName, @NotNull PsiElement psiElement) {
-    if (!METHOD_TYPE.equals(typeName)) {
+    if (!getMethodType().equals(typeName)) {
       LOG.error("unexpected type: " + typeName);
       return null;
     }

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyBrowser.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyBrowser.java
@@ -20,8 +20,8 @@ package com.intellij.plugins.haxe.ide.hierarchy.method;
 import com.intellij.ide.hierarchy.HierarchyNodeDescriptor;
 import com.intellij.ide.hierarchy.HierarchyTreeStructure;
 import com.intellij.ide.hierarchy.method.MethodHierarchyBrowser;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import org.jetbrains.annotations.NotNull;
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class HaxeMethodHierarchyBrowser extends MethodHierarchyBrowser {
 
-  Logger LOG = Logger.getInstance("#" + HaxeMethodHierarchyBrowser.class.getName());
+  HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#" + HaxeMethodHierarchyBrowser.class.getName());
 
   public HaxeMethodHierarchyBrowser(final Project project, final PsiMethod method) {
     super(project, method);

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyProvider.java
@@ -23,9 +23,9 @@ import com.intellij.ide.hierarchy.HierarchyProvider;
 import com.intellij.ide.hierarchy.MethodHierarchyBrowserBase;
 import com.intellij.ide.hierarchy.method.MethodHierarchyBrowser;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.ide.hierarchy.HaxeHierarchyUtils;
 import com.intellij.plugins.haxe.lang.psi.HaxeMethod;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiMethod;
 import org.apache.log4j.Level;
@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  * Created by ebishton on 9/3/14.
  */
 public class HaxeMethodHierarchyProvider implements HierarchyProvider {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.ide.hierarchy.type.HaxeMethodHierarchyProvider");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.ide.hierarchy.type.HaxeMethodHierarchyProvider");
 
   {
     LOG.info("Loaded HaxeMethodHierarchyProvider");

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/method/HaxeMethodHierarchyProvider.java
@@ -67,7 +67,7 @@ public class HaxeMethodHierarchyProvider implements HierarchyProvider {
     if ( LOG.isDebugEnabled() ) {
       LOG.debug( "browserActivated " + browser );
     }
-    ((MethodHierarchyBrowser) browser).changeView(MethodHierarchyBrowserBase.METHOD_TYPE);
+    ((MethodHierarchyBrowser) browser).changeView(MethodHierarchyBrowserBase.getMethodType());
   }
 
 }

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyBrowser.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyBrowser.java
@@ -20,8 +20,8 @@ package com.intellij.plugins.haxe.ide.hierarchy.type;
 import com.intellij.ide.hierarchy.HierarchyNodeDescriptor;
 import com.intellij.ide.hierarchy.HierarchyTreeStructure;
 import com.intellij.ide.hierarchy.type.TypeHierarchyBrowser;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.NotNull;
  * Created by srikanthg on 10/23/14.
  */
 public class HaxeTypeHierarchyBrowser extends TypeHierarchyBrowser {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.type.HaxeTypeHierarchyBrowser");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.type.HaxeTypeHierarchyBrowser");
 
   public HaxeTypeHierarchyBrowser(final Project project, final PsiClass psiClass) {
     super(project, psiClass);

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyBrowser.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyBrowser.java
@@ -38,13 +38,13 @@ public class HaxeTypeHierarchyBrowser extends TypeHierarchyBrowser {
 
   protected HierarchyTreeStructure createHierarchyTreeStructure(@NotNull final String typeName, @NotNull final PsiElement psiElement) {
     HierarchyTreeStructure currentActiveTree = null;
-    if (SUPERTYPES_HIERARCHY_TYPE.equals(typeName)) {
+    if (getSupertypesHierarchyType().equals(typeName)) {
       currentActiveTree = new HaxeSupertypesHierarchyTreeStructure(myProject, (PsiClass) psiElement);
     }
-    else if (SUBTYPES_HIERARCHY_TYPE.equals(typeName)) {
+    else if (getSubtypesHierarchyType().equals(typeName)) {
       currentActiveTree = new HaxeSubtypesHierarchyTreeStructure(myProject, (PsiClass) psiElement);
     }
-    else if (TYPE_HIERARCHY_TYPE.equals(typeName)) {
+    else if (getTypeHierarchyType().equals(typeName)) {
       currentActiveTree = new HaxeTypeHierarchyTreeStructure(myProject, (PsiClass) psiElement);
     }
     else {

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyProvider.java
@@ -22,10 +22,10 @@ import com.intellij.ide.hierarchy.HierarchyBrowser;
 import com.intellij.ide.hierarchy.HierarchyProvider;
 import com.intellij.ide.hierarchy.TypeHierarchyBrowserBase;
 import com.intellij.openapi.actionSystem.DataContext;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.ide.hierarchy.HaxeHierarchyUtils;
 import com.intellij.plugins.haxe.lang.psi.HaxeClass;
 import com.intellij.plugins.haxe.lang.psi.HaxeFile;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.PsiElement;
 import org.apache.log4j.Level;
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.Nullable;
  * Created by ebishton on 9/3/14.
  */
 public class HaxeTypeHierarchyProvider implements HierarchyProvider {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.ide.hierarchy.type.HaxeTypeHierarchyProvider");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.ide.hierarchy.type.HaxeTypeHierarchyProvider");
 
   static {
     LOG.info("Loaded HaxeTypeHierarchyProvider");

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyProvider.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyProvider.java
@@ -70,7 +70,7 @@ public class HaxeTypeHierarchyProvider implements HierarchyProvider {
   public void browserActivated(@NotNull HierarchyBrowser hierarchyBrowser) {
     final HaxeTypeHierarchyBrowser browser = (HaxeTypeHierarchyBrowser) hierarchyBrowser;
     final String typeName =
-      browser.isInterface() ? TypeHierarchyBrowserBase.SUBTYPES_HIERARCHY_TYPE : TypeHierarchyBrowserBase.TYPE_HIERARCHY_TYPE;
+      browser.isInterface() ? TypeHierarchyBrowserBase.getSubtypesHierarchyType() : TypeHierarchyBrowserBase.getTypeHierarchyType();
     browser.changeView(typeName);
   }
 }

--- a/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyTreeStructure.java
+++ b/src/common/com/intellij/plugins/haxe/ide/hierarchy/type/HaxeTypeHierarchyTreeStructure.java
@@ -17,8 +17,8 @@
  */
 package com.intellij.plugins.haxe.ide.hierarchy.type;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.PsiClass;
 
 /**
@@ -26,7 +26,7 @@ import com.intellij.psi.PsiClass;
  */
 public class HaxeTypeHierarchyTreeStructure extends HaxeSubtypesHierarchyTreeStructure {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.type.HaxeTypeHierarchyTreeStructure");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.hierarchy.type.HaxeTypeHierarchyTreeStructure");
 
   public HaxeTypeHierarchyTreeStructure(final Project project, final PsiClass aClass) {
     super(project, buildHierarchyElement(project, aClass));

--- a/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleSettings.java
+++ b/src/common/com/intellij/plugins/haxe/ide/module/HaxeModuleSettings.java
@@ -21,7 +21,6 @@ package com.intellij.plugins.haxe.ide.module;
 import com.intellij.openapi.components.PersistentStateComponent;
 import com.intellij.openapi.components.State;
 import com.intellij.openapi.components.Storage;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleServiceManager;
 import com.intellij.plugins.haxe.config.HaxeConfiguration;
@@ -30,6 +29,7 @@ import com.intellij.plugins.haxe.config.NMETarget;
 import com.intellij.plugins.haxe.config.OpenFLTarget;
 import com.intellij.plugins.haxe.module.HaxeModuleSettingsBase;
 import com.intellij.plugins.haxe.module.impl.HaxeModuleSettingsBaseImpl;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeModificationTracker;
 import com.intellij.plugins.haxe.util.HaxeTrackedModifiable;
 import com.intellij.util.xmlb.XmlSerializerUtil;
@@ -50,7 +50,7 @@ import org.jetbrains.annotations.Nullable;
 public class HaxeModuleSettings extends HaxeModuleSettingsBaseImpl
   implements PersistentStateComponent<HaxeModuleSettings>, HaxeModuleSettingsBase, HaxeTrackedModifiable {
 
-  private static Logger LOG = Logger.getInstance("#" + HaxeModuleSettings.class.getName());
+  private static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#" + HaxeModuleSettings.class.getName());
 
   private String flexSdkName = "";
   private HaxeModificationTracker tracker = new HaxeModificationTracker(this.getClass().getName());

--- a/src/common/com/intellij/plugins/haxe/ide/projectStructure/detection/HaxeModuleInsight.java
+++ b/src/common/com/intellij/plugins/haxe/ide/projectStructure/detection/HaxeModuleInsight.java
@@ -67,11 +67,11 @@ public class HaxeModuleInsight extends ModuleInsight {
   }
 
   @Override
-  protected void scanSourceFileForImportedPackages(CharSequence chars, Consumer<String> result) {
+  protected void scanSourceFileForImportedPackages(CharSequence chars, Consumer<? super String> result) {
   }
 
   @Override
-  protected void scanLibraryForDeclaredPackages(File file, Consumer<String> result) throws IOException {
+  protected void scanLibraryForDeclaredPackages(File file, Consumer<? super String> result) throws IOException {
   }
 
   @Override

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/extractInterface/ExtractInterfaceHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/extractInterface/ExtractInterfaceHandler.java
@@ -21,12 +21,12 @@ import com.intellij.lang.findUsages.DescriptiveNameUtil;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.ide.refactoring.extractSuperclass.ExtractSuperClassUtil;
 import com.intellij.plugins.haxe.ide.refactoring.memberPullUp.PullUpProcessor;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.refactoring.HelpID;
 import com.intellij.refactoring.RefactoringActionHandler;
@@ -44,7 +44,7 @@ import org.jetbrains.annotations.NotNull;
 import javax.swing.*;
 
 public class ExtractInterfaceHandler implements RefactoringActionHandler, ElementsHandler {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.refactoring.extractInterface.ExtractInterfaceHandler");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.refactoring.extractInterface.ExtractInterfaceHandler");
 
   public static final String REFACTORING_NAME = RefactoringBundle.message("extract.interface.title");
 

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperBaseProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperBaseProcessor.java
@@ -15,9 +15,9 @@
  */
 package com.intellij.plugins.haxe.ide.refactoring.extractSuperclass;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Comparing;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.codeStyle.JavaCodeStyleManager;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -43,7 +43,7 @@ import java.util.Collection;
  * @author dsl
  */
 public abstract class ExtractSuperBaseProcessor extends TurnRefsToSuperProcessorBase {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.refactoring.extractSuperclass.ExtractSuperClassProcessor");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.refactoring.extractSuperclass.ExtractSuperClassProcessor");
   protected PsiDirectory myTargetDirectory;
   protected final String myNewClassName;
   protected final MemberInfo[] myMemberInfos;

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperClassUtil.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperClassUtil.java
@@ -16,7 +16,6 @@
 package com.intellij.plugins.haxe.ide.refactoring.extractSuperclass;
 
 import com.intellij.codeInsight.generation.OverrideImplementExploreUtil;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtil;
@@ -30,6 +29,7 @@ import com.intellij.plugins.haxe.ide.HaxeFileTemplateUtil;
 import com.intellij.plugins.haxe.ide.refactoring.memberPullUp.PullUpProcessor;
 import com.intellij.plugins.haxe.lang.psi.HaxeFile;
 import com.intellij.plugins.haxe.lang.psi.HaxeInheritList;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.codeStyle.CodeStyleManager;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -57,7 +57,7 @@ import java.util.Set;
  * @author dsl
  */
 public class ExtractSuperClassUtil {
-  private static final Logger LOG = Logger.getInstance("com.intellij.refactoring.extractSuperclass.ExtractSuperClassUtil");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("com.intellij.refactoring.extractSuperclass.ExtractSuperClassUtil");
   public static final String REFACTORING_EXTRACT_SUPER_ID = "refactoring.extractSuper";
 
   private ExtractSuperClassUtil() {}
@@ -76,7 +76,7 @@ public class ExtractSuperClassUtil {
     //final PsiClass superclass = JavaDirectoryService.getInstance().createClass(targetDirectory, superclassName);
 
     /*for (FileTemplate template : FileTemplateManager.getInstance().getInternalTemplates()) {
-      Logger.getInstance(ExtractSuperClassUtil.class).error(template.getName());
+      HaxeDebugLogger.getInstance(ExtractSuperClassUtil.class).error(template.getName());
     }*/
 
     Module[] modules = ModuleHelper.getModules(project);
@@ -162,7 +162,7 @@ public class ExtractSuperClassUtil {
       @NonNls StringBuilder superCallText = new StringBuilder();
       superCallText.append("super(");
       final PsiClass baseClass = baseConstructor.getContainingClass();
-      LOG.assertTrue(baseClass != null);
+      LOG.assertLog(baseClass != null, "Assertion failed");
       final PsiSubstitutor classSubstitutor = TypeConversionUtil.getSuperClassSubstitutor(baseClass, superclass, PsiSubstitutor.EMPTY);
       for (int i = 0; i < baseParams.length; i++) {
         final PsiParameter baseParam = baseParams[i];

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperClassUtil.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperClassUtil.java
@@ -38,8 +38,8 @@ import com.intellij.refactoring.listeners.RefactoringEventData;
 import com.intellij.refactoring.listeners.RefactoringEventListener;
 import com.intellij.refactoring.ui.ConflictsDialog;
 import com.intellij.refactoring.util.DocCommentPolicy;
-import com.intellij.refactoring.util.RefactoringUtil;
 import com.intellij.refactoring.util.classMembers.MemberInfo;
+import com.intellij.util.CommonJavaRefactoringUtil;
 import com.intellij.util.Function;
 import com.intellij.util.IncorrectOperationException;
 import com.intellij.util.containers.HashMap;
@@ -238,7 +238,7 @@ public class ExtractSuperClassUtil {
         return findTypeParameterInDerived(derivedClass, parameter.getName()) == parameter;
       }
     };
-    final PsiTypeParameterList typeParameterList = RefactoringUtil.createTypeParameterListWithUsedTypeParameters(null, filter, PsiUtilCore.toPsiElementArray(movedElements));
+    final PsiTypeParameterList typeParameterList = CommonJavaRefactoringUtil.createTypeParameterListWithUsedTypeParameters(null, filter, PsiUtilCore.toPsiElementArray(movedElements));
     final PsiTypeParameterList originalTypeParameterList = superClass.getTypeParameterList();
     assert originalTypeParameterList != null;
     //final PsiTypeParameterList newList = typeParameterList != null ? (PsiTypeParameterList)originalTypeParameterList.replace(typeParameterList) : originalTypeParameterList;

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperclassHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/extractSuperclass/ExtractSuperclassHandler.java
@@ -27,12 +27,12 @@ import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.plugins.haxe.ide.refactoring.memberPullUp.PullUpConflictsUtil;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.refactoring.HelpID;
 import com.intellij.refactoring.RefactoringActionHandler;
@@ -51,7 +51,7 @@ import javax.swing.*;
 import java.util.List;
 
 public class ExtractSuperclassHandler implements RefactoringActionHandler, ExtractSuperclassDialog.Callback, ElementsHandler {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.refactoring.extractSuperclass.ExtractSuperclassHandler");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.refactoring.extractSuperclass.ExtractSuperclassHandler");
 
   public static final String REFACTORING_NAME = RefactoringBundle.message("extract.superclass.title");
 

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/HaxePullUpDialog.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/HaxePullUpDialog.java
@@ -72,7 +72,7 @@ public class HaxePullUpDialog extends PullUpDialogBase<MemberInfoStorage, Member
   }
 
   public HaxePullUpDialog(Project project, PsiClass aClass, List<PsiClass> superClasses, MemberInfoStorage memberInfoStorage, Callback callback) {
-    super(project, aClass, superClasses, memberInfoStorage, JavaPullUpHandler.REFACTORING_NAME);
+    super(project, aClass, superClasses, memberInfoStorage, JavaPullUpHandler.getRefactoringName());
     myCallback = callback;
 
     init();

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/HaxePullUpHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/HaxePullUpHandler.java
@@ -20,7 +20,6 @@ package com.intellij.plugins.haxe.ide.refactoring.memberPullUp;
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.progress.ProgressManager;
@@ -28,6 +27,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.DialogWrapper;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.refactoring.HelpID;
 import com.intellij.refactoring.RefactoringActionHandler;
@@ -49,7 +49,7 @@ import java.util.List;
  * Based on https://github.com/JetBrains/intellij-community/blob/master/java/java-impl/src/com/intellij/refactoring/memberPullUp/JavaPullUpHandler.java
  */
 public class HaxePullUpHandler implements RefactoringActionHandler, HaxePullUpDialog.Callback, ElementsHandler {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.ide.refactoring.memberPullUp.HaxePullUpHandler");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.ide.refactoring.memberPullUp.HaxePullUpHandler");
   public static final String REFACTORING_NAME = RefactoringBundle.message("pull.members.up.title");
   private PsiClass mySubclass;
   private Project myProject;

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/HaxePullUpHelper.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/HaxePullUpHelper.java
@@ -21,12 +21,12 @@ import com.intellij.codeInsight.PsiEquivalenceUtil;
 import com.intellij.codeInsight.intention.AddAnnotationFix;
 import com.intellij.lang.Language;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.plugins.haxe.lang.psi.HaxeMethod;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeElementGenerator;
 import com.intellij.psi.*;
 import com.intellij.psi.codeStyle.CodeStyleManager;
@@ -58,7 +58,7 @@ import java.util.*;
  * Created by Max Medvedev on 10/3/13
  */
 public class HaxePullUpHelper implements PullUpHelper<MemberInfo> {
-  private static final Logger LOG = Logger.getInstance(HaxePullUpHelper.class);
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance(HaxePullUpHelper.class);
 
   private static final Key<Boolean> PRESERVE_QUALIFIER = Key.create("PRESERVE_QUALIFIER");
 
@@ -174,7 +174,7 @@ public class HaxePullUpHelper implements PullUpHelper<MemberInfo> {
     PsiClass aClass = (PsiClass)info.getMember();
     if (Boolean.FALSE.equals(info.getOverrides())) {
       final PsiReferenceList sourceReferenceList = info.getSourceReferenceList();
-      LOG.assertTrue(sourceReferenceList != null);
+      LOG.assertLog(sourceReferenceList != null, "Assertion failed");
       PsiJavaCodeReferenceElement ref = mySourceClass.equals(sourceReferenceList.getParent()) ?
                                         RefactoringUtil.removeFromReferenceList(sourceReferenceList, aClass) :
                                         RefactoringUtil.findReferenceToClass(sourceReferenceList, aClass);

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/PullUpConflictsUtil.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/PullUpConflictsUtil.java
@@ -154,8 +154,8 @@ public class PullUpConflictsUtil {
       ContainerUtil.addIfNotNull(checkModuleConflictsList, method.getReturnTypeElement());
       ContainerUtil.addIfNotNull(checkModuleConflictsList, method.getTypeParameterList());
     }
-    RefactoringConflictsUtil.analyzeModuleConflicts(subclass.getProject(), checkModuleConflictsList,
-                                           new UsageInfo[0], targetRepresentativeElement, conflicts);
+    RefactoringConflictsUtil.getInstance().analyzeModuleConflicts(subclass.getProject(), checkModuleConflictsList,
+                                           new UsageInfo[0], targetRepresentativeElement.getContainingFile().getVirtualFile(), conflicts);
     final String fqName = subclass.getQualifiedName();
     final String packageName;
     if (fqName != null) {

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/PullUpProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/PullUpProcessor.java
@@ -178,7 +178,7 @@ public class PullUpProcessor extends BaseRefactoringProcessor implements PullUpD
           }
         });
       }
-    }, MethodDuplicatesHandler.REFACTORING_NAME, true, myProject);
+    }, MethodDuplicatesHandler.getRefactoringName(), true, myProject);
   }
 
   @Override

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/PullUpProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPullUp/PullUpProcessor.java
@@ -29,10 +29,10 @@ import com.intellij.lang.Language;
 import com.intellij.lang.findUsages.DescriptiveNameUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.application.ModalityState;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.search.searches.ClassInheritorsSearch;
 import com.intellij.psi.search.searches.ReferencesSearch;
@@ -62,7 +62,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class PullUpProcessor extends BaseRefactoringProcessor implements PullUpData {
-  private static final Logger LOG = Logger.getInstance(PullUpProcessor.class);
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance(PullUpProcessor.class);
 
   private final PsiClass mySourceClass;
   private final PsiClass myTargetSuperClass;
@@ -257,7 +257,7 @@ public class PullUpProcessor extends BaseRefactoringProcessor implements PullUpD
   }
 
   public void moveFieldInitializations() throws IncorrectOperationException {
-    LOG.assertTrue(myMembersAfterMove != null);
+    LOG.assertLog(myMembersAfterMove != null, "Assertion failed");
 
     final LinkedHashSet<PsiField> movedFields = new LinkedHashSet<PsiField>();
     for (PsiMember member : myMembersAfterMove) {

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/HaxePushDownDialog.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/HaxePushDownDialog.java
@@ -49,7 +49,7 @@ public class HaxePushDownDialog extends RefactoringDialog {
     myMemberInfos = Arrays.asList(memberInfos);
     myClass = aClass;
 
-    setTitle(JavaPushDownHandler.REFACTORING_NAME);
+    setTitle(JavaPushDownHandler.getRefactoringName());
 
     init();
   }

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/HaxePushDownDialog.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/HaxePushDownDialog.java
@@ -116,8 +116,6 @@ public class HaxePushDownDialog extends RefactoringDialog {
   protected void doAction() {
     if(!isOKActionEnabled()) return;
 
-    JavaRefactoringSettings.getInstance().PUSH_DOWN_PREVIEW_USAGES = isPreviewUsages();
-
     invokeRefactoring (new PushDownProcessor(
       getProject(), getSelectedMemberInfos(), myClass,
       new DocCommentPolicy(getJavaDocPolicy())));

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/HaxePushDownHandler.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/HaxePushDownHandler.java
@@ -49,7 +49,7 @@ public class HaxePushDownHandler extends JavaPushDownHandler {
       if (element == null || element instanceof PsiFile) {
         String message = RefactoringBundle.getCannotRefactorMessage(
           RefactoringBundle.message("the.caret.should.be.positioned.inside.a.class.to.push.members.from"));
-        CommonRefactoringUtil.showErrorHint(project, editor, message, REFACTORING_NAME, HelpID.MEMBERS_PUSH_DOWN);
+        CommonRefactoringUtil.showErrorHint(project, editor, message, getRefactoringName(), HelpID.MEMBERS_PUSH_DOWN);
         return;
       }
 

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/PushDownProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/PushDownProcessor.java
@@ -20,7 +20,6 @@ import com.intellij.codeInsight.ChangeContextUtil;
 import com.intellij.codeInsight.intention.impl.CreateClassDialog;
 import com.intellij.codeInsight.intention.impl.CreateSubclassAction;
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.progress.ProgressManager;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
@@ -29,6 +28,7 @@ import com.intellij.openapi.util.Ref;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.plugins.haxe.lang.psi.HaxeInterfaceDeclaration;
 import com.intellij.plugins.haxe.lang.psi.HaxeMethod;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeElementGenerator;
 import com.intellij.psi.*;
 import com.intellij.psi.codeStyle.CodeStyleManager;
@@ -60,7 +60,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 
 public class PushDownProcessor extends BaseRefactoringProcessor {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.refactoring.memberPushDown.PushDownProcessor");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.refactoring.memberPushDown.PushDownProcessor");
 
   private final MemberInfo[] myMemberInfos;
   private PsiClass myClass;
@@ -234,7 +234,7 @@ public class PushDownProcessor extends BaseRefactoringProcessor {
       myClass = (PsiClass) elements[0];
     }
     else {
-      LOG.assertTrue(false);
+      LOG.assertLog(false, "Assertion failed");
     }
   }
 
@@ -384,7 +384,7 @@ public class PushDownProcessor extends BaseRefactoringProcessor {
               psiClass = targetClass;
             } else if (psiClass.getContainingClass() == myClass) {
               psiClass = targetClass.findInnerClassByName(psiClass.getName(), false);
-              LOG.assertTrue(psiClass != null);
+              LOG.assertLog(psiClass != null, "Assertion failed");
             }
 
             if (!(qualifier instanceof PsiThisExpression) && ref instanceof PsiReferenceExpression) {
@@ -444,7 +444,7 @@ public class PushDownProcessor extends BaseRefactoringProcessor {
       PsiMember member = memberInfo.getMember();
       final List<PsiReference> refsToRebind = new ArrayList<PsiReference>();
       final PsiModifierList list = member.getModifierList();
-      LOG.assertTrue(list != null);
+      LOG.assertLog(list != null, "Assertion failed");
       if (list.hasModifierProperty(PsiModifier.STATIC)) {
         for (final PsiReference reference : ReferencesSearch.search(member)) {
           final PsiElement element = reference.getElement();

--- a/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/PushDownProcessor.java
+++ b/src/common/com/intellij/plugins/haxe/ide/refactoring/memberPushDown/PushDownProcessor.java
@@ -79,7 +79,7 @@ public class PushDownProcessor extends BaseRefactoringProcessor {
 
   @Override
   protected String getCommandName() {
-    return JavaPushDownHandler.REFACTORING_NAME;
+    return JavaPushDownHandler.getRefactoringName();
   }
 
   @Override
@@ -174,7 +174,7 @@ public class PushDownProcessor extends BaseRefactoringProcessor {
       if (myClass.isEnum() || myClass.hasModifierProperty(PsiModifier.FINAL)) {
         if (Messages.showOkCancelDialog((myClass.isEnum() ? "Enum " + myClass.getQualifiedName() + " doesn't have constants to inline to. " : "Final class " + myClass.getQualifiedName() + "does not have inheritors. ") +
                                         "Pushing members down will result in them being deleted. " +
-                                        "Would you like to proceed?", JavaPushDownHandler.REFACTORING_NAME, Messages.getWarningIcon()) != Messages.OK) {
+                                        "Would you like to proceed?", JavaPushDownHandler.getRefactoringName(), Messages.getWarningIcon()) != Messages.OK) {
           return false;
         }
       } else {
@@ -182,7 +182,7 @@ public class PushDownProcessor extends BaseRefactoringProcessor {
                               RefactoringBundle.message("interface.0.does.not.have.inheritors", myClass.getQualifiedName()) :
                               RefactoringBundle.message("class.0.does.not.have.inheritors", myClass.getQualifiedName());
         final String message = noInheritors + "\n" + RefactoringBundle.message("push.down.will.delete.members");
-        final int answer = Messages.showYesNoCancelDialog(message, JavaPushDownHandler.REFACTORING_NAME, Messages.getWarningIcon());
+        final int answer = Messages.showYesNoCancelDialog(message, JavaPushDownHandler.getRefactoringName(), Messages.getWarningIcon());
         if (answer == Messages.YES) {
           myCreateClassDlg = CreateSubclassAction.chooseSubclassToCreate(myClass);
           if (myCreateClassDlg != null) {

--- a/src/common/com/intellij/plugins/haxe/lang/lexer/HaxeEmbeddedElementType.java
+++ b/src/common/com/intellij/plugins/haxe/lang/lexer/HaxeEmbeddedElementType.java
@@ -46,12 +46,6 @@ public class HaxeEmbeddedElementType extends HaxeLazyParseableElementType {
     return false;
   }
 
-  @Override
-  public PsiBuilder parseLight(ASTNode chameleon) {
-    // TODO: Implement.
-    return super.parseLight(chameleon);
-  }
-
   @Nullable
   @Override
   public ASTNode createNode(CharSequence text) {

--- a/src/common/com/intellij/plugins/haxe/lang/parser/HaxeParserWrapper.java
+++ b/src/common/com/intellij/plugins/haxe/lang/parser/HaxeParserWrapper.java
@@ -17,8 +17,8 @@ package com.intellij.plugins.haxe.lang.parser;
 
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.PsiBuilder;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.metadata.lexer.HaxeMetadataTokenTypes;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeDebugTimeLog;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.impl.source.resolve.FileContextUtil;
@@ -26,7 +26,7 @@ import com.intellij.psi.tree.IElementType;
 
 public class HaxeParserWrapper extends HaxeParser {
 
-  private static Logger LOG = Logger.getInstance("#HaxeParserWrapper");
+  private static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#HaxeParserWrapper");
 
   /** Turns on debugging when running the parser.  On when the logger is in debug mode. */
   private static boolean debugging = LOG.isDebugEnabled();

--- a/src/common/com/intellij/plugins/haxe/lang/parser/HaxePsiBuilder.java
+++ b/src/common/com/intellij/plugins/haxe/lang/parser/HaxePsiBuilder.java
@@ -18,6 +18,7 @@ package com.intellij.plugins.haxe.lang.parser;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.LighterLazyParseableNode;
 import com.intellij.lang.ParserDefinition;
+import com.intellij.lang.impl.PsiBuilderFactoryImpl;
 import com.intellij.lang.impl.PsiBuilderImpl;
 import com.intellij.lexer.Lexer;
 import com.intellij.openapi.application.ApplicationManager;
@@ -68,7 +69,8 @@ public class HaxePsiBuilder extends PsiBuilderImpl {
                         @NotNull Lexer lexer,
                         @NotNull LighterLazyParseableNode chameleon,
                         @NotNull CharSequence text) {
-    super(project, parserDefinition, lexer, chameleon, text);
+    // FIXME: https://github.com/JetBrains/intellij-community/commit/bf92a4bfea21ac1269017a52a347ab32c1a87323#r105729752
+    super(project, parserDefinition, lexer, (ASTNode)chameleon, text);
     psiFile = chameleon.getContainingFile();
     setupDebugTraces();
   }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/AbstractHaxePsiClass.java
@@ -21,7 +21,6 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Condition;
 import com.intellij.openapi.util.Pair;
@@ -32,6 +31,7 @@ import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.metadata.psi.HaxeMeta;
 import com.intellij.plugins.haxe.model.*;
 import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeResolveUtil;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.*;
@@ -59,7 +59,7 @@ import java.util.List;
  */
 public abstract class AbstractHaxePsiClass extends AbstractHaxeNamedComponent implements HaxeClass {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.AbstractHaxePsiClass");
 
   private Boolean _isPrivate = null;
 
@@ -563,7 +563,7 @@ public abstract class AbstractHaxePsiClass extends AbstractHaxeNamedComponent im
     // XXX: Users of HaxeModifierList generally check for the existence of the property, not it's value.
     //      So, don't set it.
     //list.setModifierProperty(HaxePsiModifier.STATIC, false); // Haxe does not have static classes, yet!
-    LOG.assertTrue(!list.hasModifierProperty(HaxePsiModifier.STATIC), "Haxe classes cannot be static.");
+    LOG.assertLog(!list.hasModifierProperty(HaxePsiModifier.STATIC), "Haxe classes cannot be static.");
 
     return list;
   }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeInheritPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeInheritPsiMixinImpl.java
@@ -18,11 +18,11 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.psi.HaxeExtendsDeclaration;
 import com.intellij.plugins.haxe.lang.psi.HaxeImplementsDeclaration;
 import com.intellij.plugins.haxe.lang.psi.HaxeInheritPsiMixin;
 import com.intellij.plugins.haxe.lang.psi.HaxeType;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.JavaPsiFacade;
 import com.intellij.psi.PsiClassType;
 import com.intellij.psi.PsiElementFactory;
@@ -39,7 +39,7 @@ import java.util.List;
  */
 public class HaxeInheritPsiMixinImpl extends HaxePsiCompositeElementImpl implements HaxeInheritPsiMixin {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeInheritPsiMixinImpl");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeInheritPsiMixinImpl");
 
   //static {
   //  // Turn on all local messages.
@@ -97,7 +97,7 @@ public class HaxeInheritPsiMixinImpl extends HaxePsiCompositeElementImpl impleme
     } else if (this instanceof HaxeImplementsDeclaration) {
       return Role.IMPLEMENTS_LIST;
     }
-    LOG.assertTrue(false, "Unrecognized/unexpected subclass type.");
+    LOG.assertLog(false, "Unrecognized/unexpected subclass type.");
     return null;
   }
 

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeMethodPsiMixinImpl.java
@@ -21,10 +21,10 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.model.HaxeMethodModel;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.impl.PsiImplUtil;
@@ -50,7 +50,7 @@ public abstract class HaxeMethodPsiMixinImpl extends AbstractHaxeNamedComponent 
 
   // TODO: Merge this PsiMixin class(and interface) with HaxeMethod.  There is no reason to keep both, or that this be named 'mixin'.
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodPsiMixinImpl");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeMethodPsiMixinImpl");
   static {
     LOG.info("Loaded HaxeMethodPsiMixinImpl");
     LOG.setLevel(Level.DEBUG);

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeNamedElementImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeNamedElementImpl.java
@@ -20,11 +20,11 @@ package com.intellij.plugins.haxe.lang.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.navigation.ItemPresentation;
 import com.intellij.navigation.NavigationItem;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.io.FileUtil;
 import com.intellij.openapi.util.io.FileUtilRt;
 import com.intellij.plugins.haxe.HaxeComponentType;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.HaxeElementGenerator;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.search.LocalSearchScope;
@@ -41,7 +41,7 @@ import javax.swing.*;
  * @author: Fedor.Korotkov
  */
 public abstract class HaxeNamedElementImpl extends HaxePsiCompositeElementImpl implements HaxeComponentName {
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeNamedElementImpl");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeNamedElementImpl");
 
   public HaxeNamedElementImpl(@NotNull ASTNode node) {
     super(node);

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeParameterPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeParameterPsiMixinImpl.java
@@ -19,8 +19,8 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.util.IncorrectOperationException;
 import org.jetbrains.annotations.NonNls;
@@ -34,7 +34,7 @@ import java.util.Arrays;
  */
 public abstract class HaxeParameterPsiMixinImpl extends AbstractHaxeNamedComponent implements HaxeParameterPsiMixin {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeParameterBase");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeParameterBase");
 
   public HaxeParameterPsiMixinImpl(ASTNode node) {
     super(node);

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiFieldImpl.java
@@ -20,12 +20,12 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.model.HaxeEnumValueModel;
 import com.intellij.plugins.haxe.model.HaxeFieldModel;
 import com.intellij.plugins.haxe.model.HaxeModel;
 import com.intellij.plugins.haxe.util.HaxeAbstractEnumUtil;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.*;
 import com.intellij.psi.javadoc.PsiDocComment;
@@ -43,7 +43,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public abstract class HaxePsiFieldImpl extends AbstractHaxeNamedComponent implements HaxePsiField {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxePsiFieldImpl");
 
   static {
     LOG.info("Loaded HaxePsiFieldImpl");

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiTypeAdapter.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxePsiTypeAdapter.java
@@ -21,7 +21,6 @@ package com.intellij.plugins.haxe.lang.psi.impl;
 import com.intellij.lang.ASTNode;
 import com.intellij.lang.Language;
 import com.intellij.navigation.ItemPresentation;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Key;
 import com.intellij.openapi.util.TextRange;
@@ -32,6 +31,7 @@ import com.intellij.plugins.haxe.metadata.HaxeMetadataList;
 import com.intellij.plugins.haxe.metadata.psi.HaxeMeta;
 import com.intellij.plugins.haxe.metadata.psi.impl.HaxeMetadataTypeName;
 import com.intellij.plugins.haxe.metadata.util.HaxeMetadataUtils;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import com.intellij.psi.scope.PsiScopeProcessor;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -57,7 +57,7 @@ import javax.swing.*;
  */
 public class HaxePsiTypeAdapter extends PsiType implements HaxeType {
 
-  static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxePsiTypeAdapter");
+  static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxePsiTypeAdapter");
   static {
     LOG.setLevel(Level.DEBUG);
   }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypeListPartPsiMixinImpl.java
@@ -18,7 +18,6 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.Pair;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.*;
@@ -60,7 +59,7 @@ public class HaxeTypeListPartPsiMixinImpl extends HaxePsiCompositeElementImpl im
   // This type doesn't really support a class, just gives a function pointer.  So, now
   // we've got a mostly empty stub class as well...
 
-  static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeTypeListPartPsiMixinImpl");
+  static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeTypeListPartPsiMixinImpl");
   static { LOG.setLevel(Level.DEBUG); }
 
 
@@ -99,7 +98,7 @@ public class HaxeTypeListPartPsiMixinImpl extends HaxePsiCompositeElementImpl im
             myChildClass = (HaxeAnonymousType) target;
           } else {
             LOG.debug("Target: " + target.toString());
-            LOG.assertTrue(false, "Unexpected token type for child of TYPE_OR_ANONYMOUS");
+            LOG.assertLog(false, "Unexpected token type for child of TYPE_OR_ANONYMOUS");
             myChildClass = AbstractHaxePsiClass.createEmptyFacade(getProject());
           }
         } else if (HaxeTokenTypes.FUNCTION_TYPE.equals(type)) {
@@ -116,7 +115,7 @@ public class HaxeTypeListPartPsiMixinImpl extends HaxePsiCompositeElementImpl im
         }
       } else {
         // No child node?  How can this be?
-        LOG.assertTrue(false, "No child node found for TYPE_LIST_PART");
+        LOG.assertLog(false, "No child node found for TYPE_LIST_PART");
         myChildClass = AbstractHaxePsiClass.createEmptyFacade(getProject());
       }
     }

--- a/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypePsiMixinImpl.java
+++ b/src/common/com/intellij/plugins/haxe/lang/psi/impl/HaxeTypePsiMixinImpl.java
@@ -20,8 +20,8 @@
 package com.intellij.plugins.haxe.lang.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.psi.*;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.psi.*;
 import org.apache.log4j.Level;
 import org.jetbrains.annotations.Nullable;
@@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
  */
 public class HaxeTypePsiMixinImpl extends HaxePsiCompositeElementImpl implements HaxeTypePsiMixin {
 
-  private static Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeTypePsiMixin");
+  private static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.lang.psi.impl.HaxeTypePsiMixin");
   {
     LOG.setLevel(Level.DEBUG);
   }

--- a/src/common/com/intellij/plugins/haxe/metadata/psi/impl/HaxeMetaImpl.java
+++ b/src/common/com/intellij/plugins/haxe/metadata/psi/impl/HaxeMetaImpl.java
@@ -16,11 +16,11 @@
 package com.intellij.plugins.haxe.metadata.psi.impl;
 
 import com.intellij.lang.ASTNode;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes;
 import com.intellij.plugins.haxe.lang.psi.impl.HaxePsiCompositeElementImpl;
 import com.intellij.plugins.haxe.metadata.lexer.HaxeMetadataTokenTypes;
 import com.intellij.plugins.haxe.metadata.psi.*;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.PsiElement;
 import org.jetbrains.annotations.NotNull;
@@ -30,7 +30,7 @@ import java.util.Objects;
 
 public class HaxeMetaImpl extends HaxePsiCompositeElementImpl implements HaxeMeta {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.metadata.psi.impl.HaxeMetaImpl");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.metadata.psi.impl.HaxeMetaImpl");
 
   private static String CT_PREFIX = HaxeMetadataTokenTypes.CT_META_PREFIX.toString();
   private static String RT_PREFIX = HaxeMetadataTokenTypes.RT_META_PREFIX.toString();

--- a/src/common/com/intellij/plugins/haxe/metadata/util/HaxeMetadataUtils.java
+++ b/src/common/com/intellij/plugins/haxe/metadata/util/HaxeMetadataUtils.java
@@ -15,7 +15,6 @@
  */
 package com.intellij.plugins.haxe.metadata.util;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.lang.psi.HaxeCompileTimeMetaArg;
 import com.intellij.plugins.haxe.lang.psi.HaxeExpression;
 import com.intellij.plugins.haxe.metadata.HaxeMetadataList;
@@ -23,6 +22,7 @@ import com.intellij.plugins.haxe.metadata.lexer.HaxeMetadataTokenTypes;
 import com.intellij.plugins.haxe.metadata.psi.HaxeMeta;
 import com.intellij.plugins.haxe.metadata.psi.HaxeMetadataContent;
 import com.intellij.plugins.haxe.metadata.psi.impl.HaxeMetadataTypeName;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import com.intellij.plugins.haxe.util.UsefulPsiTreeUtil;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
@@ -40,7 +40,7 @@ import static com.intellij.plugins.haxe.lang.lexer.HaxeTokenTypes.EMBEDDED_META;
 
 public class HaxeMetadataUtils {
 
-  private static Logger LOG = Logger.getInstance("#HaxeMetadataUtils");
+  private static HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#HaxeMetadataUtils");
 
   private HaxeMetadataUtils() {}
 

--- a/src/common/com/intellij/plugins/haxe/runner/debugger/FakeFlexBuildConfiguration.java
+++ b/src/common/com/intellij/plugins/haxe/runner/debugger/FakeFlexBuildConfiguration.java
@@ -21,8 +21,8 @@ import com.intellij.flex.model.bc.BuildConfigurationNature;
 import com.intellij.flex.model.bc.OutputType;
 import com.intellij.flex.model.bc.TargetPlatform;
 import com.intellij.lang.javascript.flex.projectStructure.model.*;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.projectRoots.Sdk;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -35,7 +35,7 @@ public class FakeFlexBuildConfiguration implements FlexBuildConfiguration {
   private final Sdk sdk;
   private final String url;
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil");
 
   public FakeFlexBuildConfiguration(Sdk sdk, String url) {
     this.sdk = sdk;

--- a/src/common/com/intellij/plugins/haxe/runner/debugger/FakeFlexDependencies.java
+++ b/src/common/com/intellij/plugins/haxe/runner/debugger/FakeFlexDependencies.java
@@ -20,7 +20,7 @@ package com.intellij.plugins.haxe.runner.debugger;
 import com.intellij.lang.javascript.flex.projectStructure.model.Dependencies;
 import com.intellij.lang.javascript.flex.projectStructure.model.DependencyEntry;
 import com.intellij.lang.javascript.flex.projectStructure.model.SdkEntry;
-import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.plugins.haxe.util.HaxeDebugLogger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 
 public class FakeFlexDependencies implements Dependencies {
 
-  private static final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil");
+  private static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.config.sdk.HaxeSdkUtil");
   private static final DependencyEntry[] NO_DEPENDENCIES = {};
 
   @Nullable

--- a/src/common/com/intellij/plugins/haxe/util/HaxeDebugTimeLog.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeDebugTimeLog.java
@@ -33,10 +33,10 @@ import java.util.LinkedList;
 public final class HaxeDebugTimeLog {
 
   // For logging issues with this class.
-  final Logger LOG = Logger.getInstance("#com.intellij.plugins.haxe.util.HaxeDebugTimeLog");
+  final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#com.intellij.plugins.haxe.util.HaxeDebugTimeLog");
 
   // For logging time stamps that go on another logger.
-  Logger myLog;
+  HaxeDebugLogger myLog;
   LinkedList<TimeStamp> myTimeStamps;
   Since mySince;
 
@@ -59,11 +59,11 @@ public final class HaxeDebugTimeLog {
   }
 
   public HaxeDebugTimeLog(@Nullable String messagePrefix, Since since) {
-    this(Logger.getInstance(messagePrefix), since);
+    this(HaxeDebugLogger.getInstance(messagePrefix), since);
     myLog.setLevel(Level.DEBUG);
   }
 
-  public HaxeDebugTimeLog(@NotNull Logger log, Since since) {
+  public HaxeDebugTimeLog(@NotNull HaxeDebugLogger log, Since since) {
     myLog = log;
     myTimeStamps = new LinkedList<TimeStamp>();
     mySince = since;
@@ -102,7 +102,7 @@ public final class HaxeDebugTimeLog {
    * @param logger where to write the time stamp.
    * @param message text to identify the message.
    */
-  public static void logStamp(@NotNull Logger logger, @Nullable String message) {
+  public static void logStamp(@NotNull HaxeDebugLogger logger, @Nullable String message) {
     if (null == message) message = "";
     logger.debug(message + ":" + formatTime(System.currentTimeMillis()));
   }
@@ -216,7 +216,7 @@ public final class HaxeDebugTimeLog {
     myTimeStamps.add(ts);
     switch (since) {
       default:
-        LOG.assertTrue(false, "Unknown 'Since' type encountered.");
+        LOG.assertLog(false, "Unknown 'Since' type encountered.");
       case None:
         ts.log();
         break;
@@ -287,11 +287,11 @@ public final class HaxeDebugTimeLog {
       log(myLog);
     }
 
-    public void log(@NotNull Logger logger) {
+    public void log(@NotNull HaxeDebugLogger logger) {
       logger.debug(buildLogMsg(false, null, null));
     }
 
-    public void log(@NotNull Logger logger, boolean showTimeStamp, @Nullable TimeStamp first, @Nullable TimeStamp previous) {
+    public void log(@NotNull HaxeDebugLogger logger, boolean showTimeStamp, @Nullable TimeStamp first, @Nullable TimeStamp previous) {
       logger.debug(buildLogMsg(showTimeStamp, first, previous));
     }
 

--- a/src/common/com/intellij/plugins/haxe/util/HaxeDebugUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeDebugUtil.java
@@ -15,7 +15,6 @@
  */
 package com.intellij.plugins.haxe.util;
 
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.plugins.haxe.HaxeBundle;
 import com.intellij.psi.PsiElement;
@@ -34,7 +33,7 @@ import java.io.StringWriter;
  */
 public class HaxeDebugUtil {
 
-  public static final Logger cacheDebugLog = Logger.getInstance("#DisableCacheForDebugging");
+  public static final HaxeDebugLogger cacheDebugLog = HaxeDebugLogger.getInstance("#DisableCacheForDebugging");
   private static boolean disabledManually = false;
 
   /**

--- a/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/common/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -302,11 +302,13 @@ public class HaxeResolveUtil {
   @NotNull
   public static List<HaxeNamedComponent> findNamedSubComponents(boolean unique, @Nullable HaxeGenericResolver resolver, @NotNull HaxeClass... rootHaxeClasses) {
     final List<HaxeNamedComponent> unfilteredResult = new ArrayList<>();
-    final LinkedList<HaxeClass> classes = new LinkedList<>();
     final HashSet<HaxeClass> processed = new HashSet<>();
-    classes.addAll(Arrays.asList(rootHaxeClasses));
+    final List<HaxeClass> temp = Arrays.asList(rootHaxeClasses.clone());
+    final LinkedList<HaxeClass> classes = new LinkedList<>(temp);
     while (!classes.isEmpty()) {
       final HaxeClass haxeClass = classes.pollFirst();
+
+      if (haxeClass == null) continue;
 
       addNotNullComponents(unfilteredResult, getNamedSubComponents(haxeClass));
       if (haxeClass.isAbstract()) {
@@ -732,7 +734,7 @@ public class HaxeResolveUtil {
     result = getResolveMethodReturnType(resolver, iteratorResultHaxeClass, "next", iteratorResult.getSpecialization());
 
 
-    if (result.getHaxeClass() == null) {
+    if (result.getHaxeClass() == null && resolveResultHaxeClass != null) {
       // check underlying types
       SpecificHaxeClassReference underlyingClassReference = resolveResultHaxeClass.getModel().getUnderlyingClassReference(resolver);
       if(underlyingClassReference != null) {

--- a/testSrc/com/intellij/plugins/haxe/util/HaxeTestUtils.java
+++ b/testSrc/com/intellij/plugins/haxe/util/HaxeTestUtils.java
@@ -19,7 +19,6 @@
 package com.intellij.plugins.haxe.util;
 
 import com.intellij.openapi.application.PathManager;
-import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.plugins.haxe.HaxeCodeInsightFixtureTestCase;
 import com.intellij.plugins.haxe.build.IdeaTarget;
 import com.intellij.plugins.haxe.build.MethodWrapper;
@@ -43,7 +42,7 @@ import java.util.function.Consumer;
  * Created by fedorkorotkov.
  */
 public class HaxeTestUtils {
-  public static final Logger LOG = Logger.getInstance("#HaxeTestUtils");
+  public static final HaxeDebugLogger LOG = HaxeDebugLogger.getInstance("#HaxeTestUtils");
 
   public static final String HAXE_TOOLKIT_BASE_DIR = "haxe";
   public static final String HAXE_STDLIB_DIR = "std";


### PR DESCRIPTION
## Summary

This pull request is made to introduce support for modern IDEA versions starting from 2022.3. Any changes introduced by merging this pull request may break builds for older versions - read next:

## Dependencies

All plugin dependencies are upped according to bare minimum 2022.3 support. It's possible to build on any `223.*` platform version, `2022.3` and `2022.3.3` tested (entry for `flex` plugin left questionable as current `versionWithMajor` pattern does not support patch number)

- `log4j` replaced with `reload4j` as advised by: https://github.com/JetBrains/intellij-deps-log4j/commit/3de83befccd1465cfde5b8e77205659105565300: https://blog.jetbrains.com/platform/2022/02/removing-log4j-from-the-intellij-platform/
- `java` platform bumped to 17: https://blog.jetbrains.com/platform/2022/08/intellij-project-migrates-to-java-17
- `org.jetrbrains.intellij` bumped to 1.10.1 following migration guide: https://lp.jetbrains.com/gradle-intellij-plugin/#features-392
- `org.jetbrains.grammarkit` bumped to 2022.3: https://github.com/JetBrains/gradle-grammar-kit-plugin/releases/tag/v2022.3
- entries for `com.intellij.flex` + `idea_v22.properties`, fixed jvmArgs for runners and numerous adjustments for `.gradle` scripts bundled

## API updates

Overall, this refactoring contains runtime error fixes, logger library transition and transitions from not only deprecated, but **turned down** api. Be aware, these types of changes may break building on older versions **entirely**

- module `intellij-haxe:main` is completely transitioned to `HaxeDebugLogger` to fix clashing with IDEA logger initialization after moving to `reload4j`, module `intellij-haxe:common` left unchanged as constraint violation behaviour was not spotted
- `HaxeLineMarkerProvider` transitioned to updated `LineMarkerInfo` generation, but left with `DaemonBundle.message()` unchanged as modifying messages requires standardization
- `.gradle` files include fixes made when booting up main branch from older Gradle, but also includes configuration updates for newer JRE version
- all other files contains numerous updates and runtime error fixes which may break build on older JRE versions or put down builds for older IDEA version entirely; consider reviewing and testing these changes and updating `README.md` support info if needed

This pull request close #1083, close #1096 