### PR TITLE
Enable the indent options in code style settings (fixes #908)

### DIFF
--- a/src/main/java/com/intellij/plugins/haxe/ide/formatter/settings/HaxeLanguageCodeStyleSettingsProvider.java
+++ b/src/main/java/com/intellij/plugins/haxe/ide/formatter/settings/HaxeLanguageCodeStyleSettingsProvider.java
@@ -18,6 +18,7 @@
  */
 package com.intellij.plugins.haxe.ide.formatter.settings;
 
+import com.intellij.application.options.IndentOptionsEditor;
 import com.intellij.lang.Language;
 import com.intellij.plugins.haxe.HaxeLanguage;
 import com.intellij.psi.codeStyle.*;
@@ -160,6 +161,11 @@ public class HaxeLanguageCodeStyleSettingsProvider extends LanguageCodeStyleSett
                                    "ALIGN_MULTILINE_TERNARY_OPERATION",
                                    "SPECIAL_ELSE_IF_TREATMENT");
     }
+  }
+
+  @Override
+  public IndentOptionsEditor getIndentOptionsEditor() {
+    return new IndentOptionsEditor(this);
   }
 
   public static final String SPACING_CODE_SAMPLE = "package;\n" +


### PR DESCRIPTION
This is a near-exact copy of the solution proposed by @trnzk in the #908 comments, except for the added `this` parameter.

Unfortunately I have no experience in IDEA plugin development so can't write a proper test for this at the moment.

However I have tested it manually and verified that it works:

* "Tabs and Indents" tab in the settings is now present.
* Selecting "Use tab character" does switch the editor to tabs.
* Otherwise, changing "Indent" does change the number of spaces used when reformatting.
* If .editorconfig is present and enabled, it overrides the setting as expected (both indent_style and indent_size are obeyed).
* Editing, code actions, refactoring, etc do seem to obey the selected settings.
