### PR TITLE
fix OpenFL working directory when compiling

### DIFF
--- a/common/src/main/java/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
+++ b/common/src/main/java/com/intellij/plugins/haxe/util/HaxeCommonCompilerUtil.java
@@ -245,8 +245,8 @@ public class HaxeCommonCompilerUtil {
     String workingPath = null;
 
     if (settings.isUseOpenFLToBuild()) {
-      // Use the module directory...
-      workingPath = context.getModuleDirPath();
+      String openFLPath = settings.getOpenFLPath();
+      workingPath = PathUtil.getParentPath(openFLPath);
     } else if (settings.isUseNmmlToBuild()) {
       String nmmlPath = settings.getNmmlPath();
       workingPath = PathUtil.getParentPath(nmmlPath);


### PR DESCRIPTION
If the OpenFL project XML file isn't in the module directory, reported errors won't be navigable because the error won't be able to identify the source file. The error output when building OpenFL is based on the XML file location, so that should be used instead of the module directory.