### PR TITLE
fix: adjust HaxeReadWriteAccessDetector order as entry points

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -512,7 +512,9 @@
                 canCloseContents="true"
                 factoryClass="com.intellij.plugins.haxe.ide.toolWindow.HaxelibConsoleWindowFactory"/>
 
-    <readWriteAccessDetector implementation="com.intellij.plugins.haxe.ide.HaxeReadWriteAccessDetector"/>
+    <readWriteAccessDetector implementation="com.intellij.plugins.haxe.ide.HaxeReadWriteAccessDetector"
+                             id="haxe"
+                             order="first, before kotlin, before java"/>
 
     <postStartupActivity implementation="com.intellij.plugins.haxe.haxelib.HaxelibProjectStartActivity"/>
 


### PR DESCRIPTION
## BackGround

When searching for field or property usages in the current version, the read/write status is unavailable (all usages are displayed as "Read"),
even if the HaxeReadWriteAccessDetector has been implemented. However, for getter and setter usages, the read/write status is displayed normally.  

After investigation, the cause of the problem lies in `ReadWriteUtil.getReadWriteAccess`. `ReadWriteAccessDetector.EP_NAME.getExtensionList()` first returns a ReadWriteAccessDetector defined in Kotlin.
If it is provided with a PsiElement representing a Haxe field or property, the isReadWriteAccessibleElements test will pass:

```java
element instanceof PsiVariable && !(element instanceof ImplicitVariable)
```

In other words, the corresponding predicate judgment logic is intercepted by the Kotlin-defined detector, and the result is "Read".

Kotlin comes from the plugin bundled with idea. See also: [kotlin-core.xml | Kotlin plugin](https://github.com/JetBrains/intellij-community/blob/59584766384a35da0cb28e18263ae42b4741f330/plugins/kotlin/plugin/common/resources/META-INF/kotlin-core.xml#L540)

## Feature

These submissions are designed to provide these features:

- Make the read and write states in Usage available when facing fields or property.

<img width="480" height="152" alt="image" src="https://github.com/user-attachments/assets/6a20a053-7d0b-470c-bd74-fa5bd9109b49" />

## Key Changes

- **Modify**:

  in `src\main\resources\META-INF\plugin.xml`

    ```xml
    <readWriteAccessDetector implementation="com.intellij.plugins.haxe.ide.HaxeReadWriteAccessDetector"
                             id="haxe"
                             order="first, before kotlin, before java"/>
    ```

This fix makes the Usage display more useful and works on my build. I haven't tested it in Android Studio, though.