### PR TITLE
Fix import files in external libs not found

### DIFF
--- a/src/main/java/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
+++ b/src/main/java/com/intellij/plugins/haxe/util/HaxeResolveUtil.java
@@ -1199,13 +1199,32 @@ public class HaxeResolveUtil {
 
     final ProjectFileIndex fileIndex = ProjectRootManager.getInstance(file.getBasePsi().getProject()).getFileIndex();
     final VirtualFile sourceRoot = fileIndex.getSourceRootForFile(vfile);
-    if (null == sourceRoot) return true;
 
     boolean keepRunning = true;
-
     PsiDirectory parentDirectory = haxeFile.getContainingDirectory();
-    final VirtualFile stopDir = sourceRoot.getParent(); // SrcRoot is a valid place to pick up an import.hx file.
-    while (keepRunning && null != parentDirectory && !parentDirectory.getVirtualFile().equals(stopDir)) {
+
+    if (sourceRoot != null) {
+      final VirtualFile stopDir = sourceRoot.getParent(); // SrcRoot is a valid place to pick up an import.hx file.
+      while (keepRunning && null != parentDirectory && !parentDirectory.getVirtualFile().equals(stopDir)) {
+        PsiFile importFile = parentDirectory.findFile("import.hx");
+        if (importFile instanceof HaxeFile) {
+          HaxeFileModel importModel = HaxeFileModel.fromElement(importFile);
+          keepRunning = processor.apply(importModel);
+        }
+        parentDirectory = parentDirectory.getParentDirectory();
+      }
+      return keepRunning;
+    }
+
+    // sourceRoot == null: typically a file inside a haxelib library registered as
+    // Library Sources rather than a module Source Root. Derive the walk boundary
+    // from the file's package: walk (package-depth + 1) directories, which mirrors
+    // the source-root behavior (file's directory, intermediate package directories,
+    // and the package root itself, but stopping before ascending out of the package root).
+    HaxePackageStatement packageStatement = PsiTreeUtil.getStubChildOfType(haxeFile, HaxePackageStatement.class);
+    String packageName = getPackageName(packageStatement);
+    int levelsToWalk = packageName.isEmpty() ? 1 : packageName.split("\\.").length + 1;
+    for (int i = 0; i < levelsToWalk && keepRunning && parentDirectory != null; i++) {
       PsiFile importFile = parentDirectory.findFile("import.hx");
       if (importFile instanceof HaxeFile) {
         HaxeFileModel importModel = HaxeFileModel.fromElement(importFile);

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -59,6 +59,11 @@ public class HaxeSemanticAnnotatorTest extends HaxeSemanticAnnotatorTestBase {
   }
 
   @Test
+  public void testLambdaParamFromAbstractFunctionCast() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
+  @Test
   public void testFixPackage() throws Exception {
     doTestActions("Fix package");
   }

--- a/src/test/resources/testData/annotation.semantic/LambdaParamFromAbstractFunctionCast.hx
+++ b/src/test/resources/testData/annotation.semantic/LambdaParamFromAbstractFunctionCast.hx
@@ -1,0 +1,28 @@
+abstract Callback<T>(T->Void) from T->Void {}
+
+class Holder<T> {
+  public function new() {}
+  public function bind(cb:Callback<T>):Void {}
+}
+
+class LambdaParamFromAbstractFunctionCast {
+  var _intHolder:Holder<Int> = new Holder();
+  var _boolHolder:Holder<Bool> = new Holder();
+  function _voidA() {}
+  function _voidB() {}
+  function _intToVoid(v:Int) {}
+
+  function variantMatrix() {
+    // Failing case before fix: unparenthesized `_`
+    _intHolder.bind(_ -> _voidA());
+
+    // Same code path as the failing case — confirms the fix isn't `_`-specific
+    _intHolder.bind(x -> _voidA());
+
+    // Control: explicitly typed parenthesized parameter — was never broken
+    _boolHolder.bind((b:Bool) -> _voidB());
+
+    // Control: direct method reference — no inference needed
+    _intHolder.bind(_intToVoid);
+  }
+}


### PR DESCRIPTION
- Resolve import.hx for files in haxelib Library Sources where no module Source Root exists
- Derive walk boundary from package depth when sourceRoot is null
- Add LambdaParamFromAbstractFunctionCast test covering `_`, named, typed, and method-reference variants