### PR TITLE
Fix unresolved inherited fields referenced inside object literal values

### DIFF
--- a/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
+++ b/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
@@ -1156,6 +1156,10 @@ public class HaxeResolver implements ResolveCache.AbstractResolver<HaxeReference
     if (isEmpty| isThis || isSuper || isAbstract) {
 
       HaxeClass type = PsiTreeUtil.getStubOrPsiParentOfType(reference, HaxeClass.class);
+      // object literals are HaxeClass but have no superclass; walk past them to the real enclosing class.
+      while (type instanceof HaxeObjectLiteral) {
+        type = PsiTreeUtil.getStubOrPsiParentOfType(type, HaxeClass.class);
+      }
       if (type instanceof HaxeAbstractTypeDeclaration) {
 
         if(isAbstract || isEmpty) {

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeAnnotationTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeAnnotationTest.java
@@ -56,6 +56,18 @@ public class HaxeAnnotationTest extends HaxeCodeInsightFixtureTestCase {
     myFixture.testHighlighting(true, true, true, myFixture.getFile().getVirtualFile());
   }
 
+  private void doUnresolvedSymbolWarningsOnlyTest(String... additionalPaths) throws Exception {
+    final String[] paths = ArrayUtil.append(additionalPaths, getTestName(false) + ".hx");
+    myFixture.configureByFiles(ArrayUtil.reverseArray(paths));
+    myFixture.enableInspections(HaxeUnresolvedSymbolInspection.class);
+    myFixture.testHighlighting(true, false, false, myFixture.getFile().getVirtualFile());
+  }
+
+  @Test
+  public void testInheritedFieldInObjectLiteral() throws Exception {
+    doUnresolvedSymbolWarningsOnlyTest();
+  }
+
   @Test
   public void testIDEA_100331() throws Throwable {
     doTest("test/TArray.hx");

--- a/src/test/resources/testData/annotation/InheritedFieldInObjectLiteral.hx
+++ b/src/test/resources/testData/annotation/InheritedFieldInObjectLiteral.hx
@@ -1,0 +1,25 @@
+package;
+
+class Data {
+  public var flagA:Bool;
+  public var flagB:Bool;
+  public function new() { flagA = true; flagB = true; }
+}
+
+typedef Spec = {a:Bool, b:Bool};
+
+class Base {
+  private var data:Data;
+  public function new() { data = new Data(); }
+}
+
+class Child extends Base {
+  public function new() { super(); }
+
+  public function makeSpec():Spec {
+    return {
+      a: data.flagA,
+      b: data.flagB
+    };
+  }
+}


### PR DESCRIPTION
Hey. Accessing class members when creating typedefs caused errors for me.

I found that `HaxeObjectLiterals` are HaxeClass objects, but with no superclass, so `checkMemberReference` was trying to look up inherited members against the literal itself and not the actual enclosing class.
The fix tells the enclosing-class lookup to skip past any object literals and keep going up until it finds an actual class. Covered with a test that reliably reproduces this without the fix in place.