### PR TITLE
Don't flag implementations of abstract parent methods as unused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+* Fixed: Methods implementing an abstract parent method were flagged as unused (no `override` keyword required in Haxe).
+
 ## 1.8.6
 * Added: initial support for inline XML markup (parsing & basic highlighting).
 * Fixed: HXML parsing failed to parse more complex HXML file inclusion references.

--- a/src/main/java/com/intellij/plugins/haxe/ide/inspections/HaxeUnusedMethodInspection.java
+++ b/src/main/java/com/intellij/plugins/haxe/ide/inspections/HaxeUnusedMethodInspection.java
@@ -6,6 +6,7 @@ import com.intellij.plugins.haxe.ide.annotator.HaxeAnnotatingVisitor;
 import com.intellij.plugins.haxe.lang.psi.*;
 import com.intellij.plugins.haxe.metadata.psi.HaxeMetadataCompileTimeMeta;
 import com.intellij.plugins.haxe.model.HaxeClassModel;
+import com.intellij.plugins.haxe.model.HaxeMethodModel;
 import com.intellij.psi.*;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.psi.search.SearchScope;
@@ -54,6 +55,7 @@ public class HaxeUnusedMethodInspection extends LocalInspectionTool {
                 //TODO
                 if (methodDeclaration.isPublic()) return;
                 if (methodDeclaration.isOverride()) return;
+                if (implementsAbstractParentMethod(methodDeclaration)) return;
                 if (methodDeclaration.hasMetadata(OP, HaxeMetadataCompileTimeMeta.class)) return;
                 if (methodDeclaration.hasMetadata(KEEP, HaxeMetadataCompileTimeMeta.class)) return;
                 if (isGetterOrSetter(methodDeclaration)) return;
@@ -105,6 +107,15 @@ public class HaxeUnusedMethodInspection extends LocalInspectionTool {
         }
 
         return result.isEmpty() ? ProblemDescriptor.EMPTY_ARRAY : ArrayUtil.toObjectArray(result, ProblemDescriptor.class);
+    }
+
+    // Haxe does not require the `override` keyword when implementing an `abstract function`
+    // from an abstract class parent, so such impls slip past the isOverride() guard. The call
+    // site in the parent resolves only to the abstract declaration, making ReferencesSearch
+    // return no hits for the concrete impl.
+    private static boolean implementsAbstractParentMethod(@NotNull HaxeMethodDeclaration methodDeclaration) {
+        HaxeMethodModel parent = methodDeclaration.getModel().getParentMethod(null);
+        return parent != null && parent.isAbstract();
     }
 
     private static boolean isGetterOrSetter(@NotNull HaxeMethodDeclaration methodDeclaration) {

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeUnusedAnnotatorTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeUnusedAnnotatorTest.java
@@ -88,4 +88,13 @@ public class HaxeUnusedAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
         );
         doTest("UnusedMethodsTestOutside.hx");
     }
+
+    @Test
+    public void testUnusedMethodAbstractImplTest() throws Exception {
+        myFixture.enableInspections(
+                HaxeUnusedFunctionInspection.class,
+                HaxeUnusedMethodInspection.class
+        );
+        doTest();
+    }
 }

--- a/src/test/resources/testData/annotation.unused/UnusedMethodAbstractImplTest.hx
+++ b/src/test/resources/testData/annotation.unused/UnusedMethodAbstractImplTest.hx
@@ -1,0 +1,19 @@
+abstract class BaseClass {
+    public function new() {
+        test();
+    }
+
+    abstract function test():Void;
+}
+
+class TestClassOne extends BaseClass {
+    function test() {
+        trace("one");
+    }
+}
+
+class TestClassTwo extends BaseClass {
+    function test() {
+        trace("two");
+    }
+}


### PR DESCRIPTION
Hi! 👋 
Tells the method inspection for unused methods to skip when the parent method is abstract, the same way it already skips explicit overrides. Otherwise abstract functions shows up as "unused".