### PR TITLE
Type range expressions like 0...n as the std IntIterator class, so they don't show up as unresolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+* Fixed: Range expressions like `0...n` are now typed as `IntIterator` (as the compiler does), so its members and `using` extension methods on ranges resolve.
+
 ## 1.8.6
 * Added: initial support for inline XML markup (parsing & basic highlighting).
 * Fixed: HXML parsing failed to parse more complex HXML file inclusion references.

--- a/src/main/java/com/intellij/plugins/haxe/model/evaluator/HaxeExpressionEvaluatorHandlers.java
+++ b/src/main/java/com/intellij/plugins/haxe/model/evaluator/HaxeExpressionEvaluatorHandlers.java
@@ -1379,7 +1379,7 @@ public class HaxeExpressionEvaluatorHandlers {
           HaxeTypeLiteralsUtils.getIntValue(right.getConstant())
         );
       }
-      return SpecificHaxeClassReference.getIterator(SpecificHaxeClassReference.getInt(iteratorExpression)).withConstantValue(constant)
+      return SpecificHaxeClassReference.getIntIterator(iteratorExpression).withConstantValue(constant)
         .createHolder();
     }
     return createUnknown(iteratorExpression);

--- a/src/main/java/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
+++ b/src/main/java/com/intellij/plugins/haxe/model/type/SpecificTypeReference.java
@@ -55,6 +55,7 @@ public abstract class SpecificTypeReference {
   public static final String FLAT_ENUM = "haxe.Constraints.FlatEnum";
   public static final String UNKNOWN = "unknown"; // TODO: Should NOT a legal type name.
   public static final String ITERATOR = "Iterator";
+  public static final String INT_ITERATOR = "IntIterator";
   public static final String FUNCTION = "Function";
   public static final String INVALID = "@@Invalid";
   public static final String MAP = "haxe.ds.Map";
@@ -222,6 +223,19 @@ public abstract class SpecificTypeReference {
     final PsiElement context = type.getElementContext();
     final HaxeClassReference classReference = getStdClassReference(ITERATOR, context);
     return SpecificHaxeClassReference.withGenerics(classReference, new ResultHolder[]{type.createHolder()});
+  }
+
+  /**
+   * The compiler types range expressions (`min...max`) as the std class IntIterator, not as the
+   * structural Iterator&lt;Int&gt; typedef; extension methods declared for IntIterator only apply
+   * to the nominal type. Falls back to Iterator&lt;Int&gt; if the SDK std is incomplete.
+   */
+  public static SpecificHaxeClassReference getIntIterator(@NotNull PsiElement context) {
+    final HaxeClassModel model = getStdTypeModel(INT_ITERATOR, context);
+    if (model != null) {
+      return SpecificHaxeClassReference.withoutGenerics(new HaxeClassReference(model, context));
+    }
+    return getIterator(getInt(context));
   }
 
   public static SpecificHaxeClassReference getFunction(@NotNull PsiElement context) {

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -325,6 +325,12 @@ public class HaxeSemanticAnnotatorTest extends HaxeSemanticAnnotatorTestBase {
   }
 
   @Test
+  public void testIntIteratorExtensionMethods() throws Exception {
+    myFixture.enableInspections(HaxeUnresolvedSymbolInspection.class);
+    doTestNoFixWithWarnings("extensions/IntIteratorExtensions.hx");
+  }
+
+  @Test
   public void testFieldInitializerCheck() throws Exception {
     doTestNoFixWithWarnings();
   }

--- a/src/test/resources/testData/annotation.semantic/IntIteratorExtensionMethods.hx
+++ b/src/test/resources/testData/annotation.semantic/IntIteratorExtensionMethods.hx
@@ -1,0 +1,31 @@
+using extensions.IntIteratorExtensions;
+
+class Test {
+    static function main() {
+        var letters = ["a", "b", "c"];
+
+        // a `min...max` range is an IntIterator, so extension methods on IntIterator must apply
+        for (i in (0...letters.length).reverse()) {
+            var s:String = letters[i];
+        }
+
+        // extension methods declared against Iterator<Int> apply too (IntIterator unifies structurally)
+        var total:Int = (0...letters.length).sum();
+
+        // IntIterator instance members resolve on range expressions
+        var range = 0...letters.length;
+        var more:Bool = range.hasNext();
+
+        // ranges can be assigned to IntIterator as well as Iterator<Int>
+        var typed:IntIterator = 0...10;
+        var structural:Iterator<Int> = 0...10;
+
+        // plain range loops still infer Int elements
+        for (i in 0...letters.length) {
+            var ok:Int = i;
+        }
+
+        // unknown members are still reported
+        (0...10).<warning descr="Unresolved symbol">notARealExtension</warning>();
+    }
+}

--- a/src/test/resources/testData/annotation.semantic/extensions/IntIteratorExtensions.hx
+++ b/src/test/resources/testData/annotation.semantic/extensions/IntIteratorExtensions.hx
@@ -1,0 +1,15 @@
+package extensions;
+
+class IntIteratorExtensions {
+    public static function reverse(it:IntIterator):Array<Int> {
+        var result = [for (i in it) i];
+        result.reverse();
+        return result;
+    }
+
+    public static function sum(it:Iterator<Int>):Int {
+        var total = 0;
+        for (i in it) total += i;
+        return total;
+    }
+}


### PR DESCRIPTION
Hi! 👋
Range expressions like `0...n` showed up as unresolved, also extension methods and members like `hasNext()`. This types them as `IntIterator` class (falling back to Iterator<Int> when the SDK doesn't have it), matching the compiler. 
