### PR TITLE
Exclude parser/lexer generator tasks from the Gradle build cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## Unreleased
+* Misc: Disabled Gradle build cache for the parser/lexer generator tasks (their outputs overlap in src/main/gen, so a restored cache snapshot could bring back stale generated sources).
+
 ## 1.8.6
 * Added: initial support for inline XML markup (parsing & basic highlighting).
 * Fixed: HXML parsing failed to parse more complex HXML file inclusion references.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -328,3 +328,16 @@ tasks.register<GenerateLexerTask>("generateHxmlLexer") {
     purgeOldFiles = false
 }
 
+// All generator tasks write into the shared src/main/gen tree, so their declared
+// outputs overlap. Overlapping outputs are not safely cacheable: restoring one
+// grammar's cached directory snapshot resurrects stale copies of the *other*
+// grammars' files (e.g. an old HaxeParser.java reappearing after haxe.bnf changed,
+// which made FunctionTypeSyntaxTest fail in roughly every second clean build).
+// Generation is cheap; never store or load these outputs from the build cache.
+tasks.withType<GenerateParserTask>().configureEach {
+    outputs.cacheIf("overlapping outputs in src/main/gen are not safely cacheable") { false }
+}
+tasks.withType<GenerateLexerTask>().configureEach {
+    outputs.cacheIf("overlapping outputs in src/main/gen are not safely cacheable") { false }
+}
+


### PR DESCRIPTION
Hi! 👋
This disables Gradle build-cache storage for the parser/lexer generator tasks. All grammar-generator tasks write into the same `src/main/gen` directory, and restoring a cached snapshot for one grammar can bring back stale generated files from another. I believe that's also why `FunctionTypeSyntaxTest` sometimes seemed to failed randomly.