### PR TITLE
Fix IllegalArgumentException during mid-edit highlighting by null-guarding the expression evaluator's callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Fixed: IllegalArgumentException during highlighting when a switch, call expression or object-literal member is still incomplete while editing.
+
 ## 1.8.6
 * Changed: Completion suggestions inside `@:forward` will now only show suggestions for unerlying type members. 
 * Fixed: Methods implementing an abstract parent method were flagged as unused (no `override` keyword required in Haxe). (fixed by Tobbse - #1254)

--- a/src/main/java/com/intellij/plugins/haxe/ide/annotator/semantics/HaxeReturnStatementAnnotator.java
+++ b/src/main/java/com/intellij/plugins/haxe/ide/annotator/semantics/HaxeReturnStatementAnnotator.java
@@ -287,7 +287,12 @@ public class HaxeReturnStatementAnnotator implements Annotator {
     }
 
     private static boolean isSwitchOnEnum(HaxeSwitchStatement switchStatement) {
-        ResultHolder switchType = HaxeExpressionEvaluator.evaluate(switchStatement.getExpression()).result;
+        HaxeExpression expression = switchStatement.getExpression();
+        if (expression == null) {
+            // Incomplete switch (no scrutinee yet).
+            return false;
+        }
+        ResultHolder switchType = HaxeExpressionEvaluator.evaluate(expression).result;
         if(switchType.getClassType() != null) {
             SpecificTypeReference specificTypeReference = switchType.getClassType().fullyResolveTypeDefAndUnwrapNullTypeReference();
             switchType = specificTypeReference.createHolder();

--- a/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
+++ b/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
@@ -981,7 +981,12 @@ public final class HaxeResolver implements ResolveCache.AbstractResolver<HaxeRef
           index = 0;
         }
         if(PossibleCallExpression instanceof  HaxeCallExpression callExpression) {
-          ResultHolder result = HaxeExpressionEvaluator.evaluate(callExpression.getExpression(), new HaxeGenericResolver()).result;
+          HaxeExpression callee = callExpression.getExpression();
+          if (callee == null) {
+            // Incomplete call expression (no callee yet).
+            return null;
+          }
+          ResultHolder result = HaxeExpressionEvaluator.evaluate(callee, new HaxeGenericResolver()).result;
           SpecificFunctionReference functionType = result.getFunctionType();
           if(functionType != null) {
             List<HaxeArgument> arguments = functionType.getArguments();
@@ -1738,7 +1743,12 @@ public final class HaxeResolver implements ResolveCache.AbstractResolver<HaxeRef
           lastElement = members.isEmpty() ? null : members.getFirst();
           
         } else if(switchStatement != null){
-          ResultHolder resultHolder = HaxeExpressionEvaluator.evaluate(switchStatement.getExpression()).result;
+          HaxeExpression switchExpression = switchStatement.getExpression();
+          if (switchExpression == null) {
+            // Incomplete switch (no scrutinee yet).
+            continue;
+          }
+          ResultHolder resultHolder = HaxeExpressionEvaluator.evaluate(switchExpression).result;
           if (resultHolder != null && resultHolder.getClassType() != null) {
             HaxeClass haxeClass = resultHolder.getClassType().getHaxeClass();
             if (haxeClass != null) {

--- a/src/main/java/com/intellij/plugins/haxe/model/HaxeObjectLiteralMemberModel.java
+++ b/src/main/java/com/intellij/plugins/haxe/model/HaxeObjectLiteralMemberModel.java
@@ -1,6 +1,7 @@
 package com.intellij.plugins.haxe.model;
 
 import com.intellij.plugins.haxe.lang.psi.HaxeComponentName;
+import com.intellij.plugins.haxe.lang.psi.HaxeExpression;
 import com.intellij.plugins.haxe.lang.psi.HaxeObjectLiteral;
 import com.intellij.plugins.haxe.lang.psi.HaxeObjectLiteralElement;
 import com.intellij.plugins.haxe.model.evaluator.HaxeExpressionEvaluator;
@@ -51,6 +52,11 @@ public class HaxeObjectLiteralMemberModel extends HaxeBaseMemberModel {
   }
   @Override
   public ResultHolder getResultType(@Nullable HaxeGenericResolver resolver) {
-    return HaxeExpressionEvaluator.evaluate(myPsi.getExpression(), resolver).result;
+    HaxeExpression expression = myPsi.getExpression();
+    if (expression == null) {
+      // Object-literal member without a value (incomplete user input, error recovery).
+      return SpecificHaxeClassReference.getUnknown(myPsi).createHolder();
+    }
+    return HaxeExpressionEvaluator.evaluate(expression, resolver).result;
   }
 }

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeAnnotationTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeAnnotationTest.java
@@ -68,6 +68,15 @@ public class HaxeAnnotationTest extends HaxeCodeInsightFixtureTestCase {
     doUnresolvedSymbolWarningsOnlyTest();
   }
 
+  /*
+   * When an object-literal member has no value expression HaxeObjectLiteralElement.getExpression() should not return null.
+   */
+  @Test
+  public void testIncompleteObjectLiteralMember() throws Exception {
+    myFixture.configureByFile(getTestName(false) + ".hx");
+    myFixture.doHighlighting();
+  }
+
   @Test
   public void testIDEA_100331() throws Throwable {
     doTest("test/TArray.hx");

--- a/src/test/resources/testData/annotation/IncompleteObjectLiteralMember.hx
+++ b/src/test/resources/testData/annotation/IncompleteObjectLiteralMember.hx
@@ -1,0 +1,17 @@
+package;
+
+typedef Spec = { name:String };
+
+class Holder {
+  public function new(spec:Spec) {}
+}
+
+class Test {
+  public static function main() {
+    // The member 'name' has no value expression — GrammarKit error-recovery
+    // produces a HaxeObjectLiteralElement whose getExpression() is null.
+    // The line-marker / resolve pass must not crash with IllegalArgumentException
+    // on the @NotNull 'element' parameter of HaxeExpressionEvaluator.evaluate.
+    new Holder({name: });
+  }
+}


### PR DESCRIPTION
Hi! 👋
This attempts to get rid of some `IllegalArgumentException`s that broke highlighting passes during editing.

Basically adds some null-guarding to expression evaluation (resolver, return-statement annotator, object-literal member model) when the expression child is still missing. Added a regression test with an incomplete object literal.