### PR TITLE
Resolve @:using extension methods when called on enum values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Fixed: Methods provided via `@:using` on an enum were reported as unresolved when called on an enum value.
+
 ## 1.8.6
 * Changed: Completion suggestions inside `@:forward` will now only show suggestions for unerlying type members. 
 * Fixed: Methods implementing an abstract parent method were flagged as unused (no `override` keyword required in Haxe). (fixed by Tobbse - #1254)

--- a/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
+++ b/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
@@ -2511,19 +2511,16 @@ public final class HaxeResolver implements ResolveCache.AbstractResolver<HaxeRef
     }
     // TODO mlo: clean up (separate members and extension methods)
     SpecificTypeReference type = result != null && !result.isUnknown() ? result.getType()  : null;
+    SpecificHaxeClassReference classType = result == null || result.isUnknown() ? null : result.getClassType();
     // Enum values don't have a HaxeClass via ResultHolder.getClassType, but for resolving
     // members and `@:using`/`using`-imported extension methods we need the declaring enum class
     // (e.g. for `MyEnum.SomeValue.method()` the receiver is `MyEnum`).
     boolean fromEnumValue = false;
-    SpecificHaxeClassReference enumClassOverride = null;
     if (type instanceof SpecificEnumValueReference valueReference) {
-      enumClassOverride = valueReference.getEnumClass();
-      type = enumClassOverride;
+      classType = valueReference.getEnumClass();
+      type = classType;
       fromEnumValue = true;
     }
-    SpecificHaxeClassReference classType = enumClassOverride != null
-                                           ? enumClassOverride
-                                           : (result == null || result.isUnknown() ? null : result.getClassType());
     HaxeClass  haxeClass = classType != null ? classType.getHaxeClass() : null;
 
 

--- a/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
+++ b/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
@@ -2511,14 +2511,19 @@ public final class HaxeResolver implements ResolveCache.AbstractResolver<HaxeRef
     }
     // TODO mlo: clean up (separate members and extension methods)
     SpecificTypeReference type = result != null && !result.isUnknown() ? result.getType()  : null;
-    //enum values does not have a HaxeClass but we need a class for a lot of the checks below (extension methods etc),
-    // so we use the EnumValue as class as a replacement
+    // Enum values don't have a HaxeClass via ResultHolder.getClassType, but for resolving
+    // members and `@:using`/`using`-imported extension methods we need the declaring enum class
+    // (e.g. for `MyEnum.SomeValue.method()` the receiver is `MyEnum`).
     boolean fromEnumValue = false;
+    SpecificHaxeClassReference enumClassOverride = null;
     if (type instanceof SpecificEnumValueReference valueReference) {
-      type = getEnumValue(valueReference.context);
+      enumClassOverride = valueReference.getEnumClass();
+      type = enumClassOverride;
       fromEnumValue = true;
     }
-    SpecificHaxeClassReference classType = result == null || result.isUnknown() ? null : result.getClassType();
+    SpecificHaxeClassReference classType = enumClassOverride != null
+                                           ? enumClassOverride
+                                           : (result == null || result.isUnknown() ? null : result.getClassType());
     HaxeClass  haxeClass = classType != null ? classType.getHaxeClass() : null;
 
 

--- a/src/test/java/com/intellij/plugins/haxe/resolve/HaxeExpressionResolveTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/resolve/HaxeExpressionResolveTest.java
@@ -68,4 +68,9 @@ public class HaxeExpressionResolveTest extends HaxeCodeInsightFixtureTestCase {
   public void testEnumExtensions() {
     doTest();
   }
+
+  @Test
+  public void testEnumUsingMetaExtension() {
+    doTest("colors/Color.hx");
+  }
 }

--- a/src/test/resources/testData/resolve/expressions/EnumUsingMetaExtension.hx
+++ b/src/test/resources/testData/resolve/expressions/EnumUsingMetaExtension.hx
@@ -1,0 +1,10 @@
+package;
+
+import <info descr="null">colors.Color</info>;
+
+class <info descr="null">Demo</info> {
+  public function <info descr="null">new</info>() {}
+  public function <info descr="null">show</info>():<info descr="null">String</info> {
+    return <info descr="null">Color</info>.<info descr="null">Red</info>.<info descr="null">label</info>();
+  }
+}

--- a/src/test/resources/testData/resolve/expressions/colors/Color.hx
+++ b/src/test/resources/testData/resolve/expressions/colors/Color.hx
@@ -1,0 +1,14 @@
+package colors;
+
+@:using(colors.Color.ColorTools)
+enum Color {
+  Red;
+  Green;
+  Blue;
+}
+
+private class ColorTools {
+  public static function label(value:Color):String {
+    return "color";
+  }
+}


### PR DESCRIPTION
Hi! 👋
Resolves methods provided via @:using on an enum when they're called on an enum value.
Otherwise those extension methods show up as "Unresolved symbol" even though the compiler accepts them. Added a resolve test with an example.