### PR TITLE
Type bodyless macro stubs as Dynamic instead of inferring Void

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased
+* Fixed: Bodyless macro stubs are now typed `Dynamic` instead of having `Void` inferred from the missing body, so assignments from their calls are no longer flagged as incompatible.
 
 ## 1.8.6
 * Changed: Completion suggestions inside `@:forward` will now only show suggestions for unerlying type members. 

--- a/src/main/java/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
+++ b/src/main/java/com/intellij/plugins/haxe/model/type/HaxeTypeResolver.java
@@ -385,6 +385,14 @@ public class HaxeTypeResolver {
               .toList();
 
       if (returnTypes.isEmpty() && returnStatementList.isEmpty()) {
+        // A bodyless macro stub (e.g. `public macro function make(_);`) forwards to a
+        // sibling macro implementation that produces an Expr whose type is determined per
+        // call site (typically via Context.getExpectedType). Treat it as Dynamic to mirror
+        // how resolveMacroTypesForFunction already maps an Expr macro return type, instead
+        // of falling through to Void which causes false-positive "Void should be X" errors.
+        if (methodModel.isMacro() && methodModel.getBodyPsi() == null) {
+          return SpecificHaxeClassReference.getDynamic(psi).createHolder();
+        }
         return SpecificHaxeClassReference.getVoid(psi).createHolder();
       }
       if (returnStatementList.isEmpty()) {

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -1124,6 +1124,11 @@ public class HaxeSemanticAnnotatorTest extends HaxeSemanticAnnotatorTestBase {
     doTestNoFixWithWarnings();
   }
   @Test
+  public void testMacroStubReturnTypeIsNotVoid() throws Throwable {
+    myFixture.enableInspections(HaxeUnresolvedSymbolInspection.class);
+    doTestNoFixWithWarnings();
+  }
+  @Test
   public void testTypeTagsShouldNotResolveToEnumValue() throws Throwable {
     myFixture.enableInspections(HaxeUnresolvedSymbolInspection.class);
     doTestNoFixWithWarnings();

--- a/src/test/resources/testData/annotation.semantic/MacroStubReturnTypeIsNotVoid.hx
+++ b/src/test/resources/testData/annotation.semantic/MacroStubReturnTypeIsNotVoid.hx
@@ -1,0 +1,23 @@
+package;
+
+class TestClass {
+  public function new() {}
+}
+
+class Factory {
+  public function new() {}
+
+  // Bodyless macro stub. The actual implementation lives in a sibling macro
+  // class and uses `Context.getExpectedType()` to determine the return type
+  // per call site. The IntelliJ plugin must not treat the missing body as a
+  // signal that this method returns Void.
+  public macro function make(_);
+}
+
+class TheTest {
+  public function new() {
+    var factory = new Factory();
+    final test:TestClass = factory.make();
+    trace(test);
+  }
+}


### PR DESCRIPTION
Hi! 👋
Types macro stubs without a body (like `public macro function f(_);`) as Dynamic instead of inferring `Void` from the missing body.

Otherwise every assignment from such a call gets flagged with "Incompatible type: Void should be X". The real return type is decided per call site by the macro implementation. Macros with a body or an explicit return type should be unaffected.