### PR TITLE
Stop the unused-method inspection crashing on module-level functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Fixed: The unused-method inspection crashed with a NullPointerException on module-level functions.
+
 ## 1.8.6
 * Changed: Completion suggestions inside `@:forward` will now only show suggestions for unerlying type members. 
 * Fixed: Methods implementing an abstract parent method were flagged as unused (no `override` keyword required in Haxe). (fixed by Tobbse - #1254)

--- a/src/main/java/com/intellij/plugins/haxe/model/HaxeMethodModel.java
+++ b/src/main/java/com/intellij/plugins/haxe/model/HaxeMethodModel.java
@@ -236,7 +236,10 @@ public class HaxeMethodModel extends HaxeMemberModel implements HaxeExposableMod
   }
 
   public HaxeMethodModel getParentMethod(@Nullable HaxeGenericResolver resolver) {
-    final HaxeClassModel aClass = getDeclaringClass().getParentClass();
+    // Module-level functions have no declaring class, so there is no parent method to find.
+    final HaxeClassModel declaringClass = getDeclaringClass();
+    if (declaringClass == null) return null;
+    final HaxeClassModel aClass = declaringClass.getParentClass();
     return (aClass != null) ? aClass.getMethod(this.getName(), resolver) : null;
   }
 

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeUnusedAnnotatorTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeUnusedAnnotatorTest.java
@@ -97,4 +97,13 @@ public class HaxeUnusedAnnotatorTest extends HaxeCodeInsightFixtureTestCase {
         );
         doTest();
     }
+
+    @Test
+    public void testUnusedModuleLevelFunctionTest() throws Exception {
+        myFixture.enableInspections(
+                HaxeUnusedFunctionInspection.class,
+                HaxeUnusedMethodInspection.class
+        );
+        doTest();
+    }
 }

--- a/src/test/resources/testData/annotation.unused/UnusedModuleLevelFunctionTest.hx
+++ b/src/test/resources/testData/annotation.unused/UnusedModuleLevelFunctionTest.hx
@@ -1,0 +1,9 @@
+// Module-level functions parse as HaxeModuleMethodDeclaration (a subtype of
+// HaxeMethodDeclaration) but have no declaring class. The unused-method
+// inspection used to call getParentMethod() on them, which dereferenced the
+// null declaring class and threw an NPE. This fixture makes sure the
+// inspection runs to completion and still flags an unused module-level
+// function as a method.
+function <warning descr="Method 'unusedModuleLevelFunction' is never used">unusedModuleLevelFunction</warning>() {
+    trace("never called");
+}


### PR DESCRIPTION
Hi! 👋
This PR adds a null guard in `HaxeMethodModel.getParentMethod()` to make sure the unused-method inspection for module-level functions does not crash with a `NullPointerException`.

Unused module-level functions are still flagged, there's a test for it.