### PR TITLE
Type bare class references in object literal fields as Class<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased
+* Fixed: Bare class references in object literal fields are now typed as `Class<T>`, so such literals unify with typedefs that have Class-typed members.
 
 ## 1.8.6
 * Changed: Completion suggestions inside `@:forward` will now only show suggestions for unerlying type members. 

--- a/src/main/java/com/intellij/plugins/haxe/model/evaluator/HaxeExpressionEvaluatorHandlers.java
+++ b/src/main/java/com/intellij/plugins/haxe/model/evaluator/HaxeExpressionEvaluatorHandlers.java
@@ -353,15 +353,12 @@ public class HaxeExpressionEvaluatorHandlers {
             else {
               typeHolder = SpecificHaxeClassReference.withoutGenerics(classReference).createHolder();
             }
-            // make sure we do not wrap type in class if reference is type in ObjectLiteral
-            if (!(element.getParent() instanceof HaxeObjectLiteralElement)) {
-              // check if pure Class Reference
-              if (reference instanceof HaxeReferenceExpressionImpl expression) {
-                if (expression.isPureClassReferenceOf(haxeClass)) {
-                  // make sure its not an import statement
-                  if (PsiTreeUtil.getParentOfType(expression, HaxeImportStatement.class) == null) {
-                    typeHolder = wrapTypeInClassOrEnum(element,  haxeClass);
-                  }
+            // check if pure Class Reference
+            if (reference instanceof HaxeReferenceExpressionImpl expression) {
+              if (expression.isPureClassReferenceOf(haxeClass)) {
+                // make sure its not an import statement
+                if (PsiTreeUtil.getParentOfType(expression, HaxeImportStatement.class) == null) {
+                  typeHolder = wrapTypeInClassOrEnum(element,  haxeClass);
                 }
               }
             }

--- a/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/ide/HaxeSemanticAnnotatorTest.java
@@ -579,6 +579,11 @@ public class HaxeSemanticAnnotatorTest extends HaxeSemanticAnnotatorTestBase {
   }
 
   @Test
+  public void testObjectLiteralWithTypedefArrayFields() throws Exception {
+    doTestNoFixWithWarnings();
+  }
+
+  @Test
   public void testAssignTypedefToInt() throws Exception {
     doTestNoFixWithWarnings();
   }

--- a/src/test/resources/testData/annotation.semantic/ObjectLiteralWithTypedefArrayFields.hx
+++ b/src/test/resources/testData/annotation.semantic/ObjectLiteralWithTypedefArrayFields.hx
@@ -1,0 +1,75 @@
+// This test should show no errors.
+package;
+
+interface IHandler {}
+class FirstHandler implements IHandler {}
+class SecondHandler implements IHandler {}
+class SomeModel {}
+class SomeView {}
+
+class EventNames {
+  public static inline final FIRST:String = "first";
+  public static inline final SECOND:String = "second";
+}
+
+typedef ConditionPart = {
+  var ?condition:Int;
+}
+
+typedef ModelEntry = {
+  var modelClass:Class<Dynamic>;
+  var ?createInstance:Bool;
+  var ?mappingClass:Class<Dynamic>;
+} & ConditionPart;
+
+typedef HandlerEntry = {
+  var eventName:String;
+  var handlerClass:Class<IHandler>;
+  var ?priority:Int;
+}
+
+typedef ViewEntry = {
+  var viewClass:Class<Dynamic>;
+  var handlerClass:Class<IHandler>;
+  var ?lazy:Bool;
+}
+
+typedef Config = {
+  var models:Array<ModelEntry>;
+  var views:Array<ViewEntry>;
+  var ?handlers:Array<HandlerEntry>;
+}
+
+class Holder {
+  final _config:Config;
+  public function new(config:Config) {
+    _config = config;
+  }
+}
+
+class Test {
+  // literal passed straight to a constructor parameter (static final field initializer)
+  public static final holder = new Holder({
+    models: [
+      {modelClass: SomeModel}
+    ],
+    handlers: [
+      {eventName: EventNames.FIRST, handlerClass: FirstHandler},
+      {eventName: EventNames.SECOND, handlerClass: SecondHandler},
+    ],
+    views: [
+      {viewClass: SomeView, handlerClass: FirstHandler}
+    ]
+  });
+
+  static function main() {
+    // simpler variants: array literals of anonymous structures assigned to typed locals
+    var a:Array<HandlerEntry> = [{eventName: "x", handlerClass: FirstHandler}];
+    var b:Array<ViewEntry> = [{viewClass: SomeView, handlerClass: FirstHandler}];
+    var c:Array<ModelEntry> = [{modelClass: SomeModel}];
+
+    // single elements (no array wrapping)
+    var d:HandlerEntry = {eventName: "x", handlerClass: FirstHandler};
+    var e:ModelEntry = {modelClass: SomeModel};
+  }
+}


### PR DESCRIPTION
Hi! 👋
This removes a check for `HaxeObjectLiteralElement` in `HaxeExpressionEvaluatorHandlers.java`. Not sure why this was in place.
Otherwise the code below gets flagged and `handlerClass` would be typed with the instance type `MyHandler` instead of `Class<MyHandler>`.

```
class MyHandler {}

typedef Entry = {
  var handlerClass:Class<MyHandler>;
}

class Main {
  static function main() {
    var e:Entry = {handlerClass: MyHandler}; // IDE showed an error here
  }
}
```

Added a test as well.