### PR TITLE
Add go-to-declaration on object literal keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Added: Go-to-declaration (Ctrl/Cmd+Click) on object literal keys, jumping to the matching field of the type the literal is used as (including extended and intersection typedefs).
+
 ## 1.8.6
 * Changed: Completion suggestions inside `@:forward` will now only show suggestions for unerlying type members. 
 * Fixed: Methods implementing an abstract parent method were flagged as unused (no `override` keyword required in Haxe). (fixed by Tobbse - #1254)

--- a/src/main/java/com/intellij/plugins/haxe/ide/HaxeGotoDeclarationHandler.java
+++ b/src/main/java/com/intellij/plugins/haxe/ide/HaxeGotoDeclarationHandler.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2014-2014 AS3Boyan
+ * Copyright 2014-2014 Elias Ku
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.intellij.plugins.haxe.ide;
+
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationHandler;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.plugins.haxe.lang.psi.HaxeObjectLiteral;
+import com.intellij.plugins.haxe.lang.psi.HaxeObjectLiteralComponentName;
+import com.intellij.plugins.haxe.lang.psi.HaxeObjectLiteralElement;
+import com.intellij.plugins.haxe.lang.psi.HaxeResolver;
+import com.intellij.plugins.haxe.model.HaxeBaseMemberModel;
+import com.intellij.plugins.haxe.model.HaxeClassModel;
+import com.intellij.plugins.haxe.model.evaluator.HaxeExpressionEvaluator;
+import com.intellij.plugins.haxe.model.evaluator.HaxeExpressionEvaluatorContext;
+import com.intellij.plugins.haxe.model.type.HaxeGenericResolver;
+import com.intellij.plugins.haxe.model.type.ResultHolder;
+import com.intellij.plugins.haxe.model.type.SpecificHaxeClassReference;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.PsiTreeUtil;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Lets you Ctrl/Cmd+Click the <em>key</em> of an object literal and jump to the field it fills in
+ * on the structure the literal is typed against.
+ *
+ * <p>For {@code var c:Config = { name: "x" }} clicking {@code name} navigates to the {@code name}
+ * field declared in {@code Config}. The field is looked up through the structure's full member set,
+ * so it also works when {@code Config} extends (or is built from) other typedefs.</p>
+ *
+ * <p>The object literal key is otherwise a field <em>declaration</em> on the literal's own anonymous
+ * type (it has no reference), so plain reference resolution never produces a navigation target here.
+ * This handler adds that target without touching find-usages, rename or highlighting.</p>
+ */
+public class HaxeGotoDeclarationHandler implements GotoDeclarationHandler {
+
+  @Override
+  public PsiElement @Nullable [] getGotoDeclarationTargets(@Nullable PsiElement sourceElement, int offset, Editor editor) {
+    if (sourceElement == null) return null;
+
+    HaxeObjectLiteralElement literalElement = PsiTreeUtil.getParentOfType(sourceElement, HaxeObjectLiteralElement.class);
+    if (literalElement == null) return null;
+
+    HaxeObjectLiteralComponentName key = literalElement.getComponentName();
+    if (key == null) return null;
+
+    // Only react when the click is on the key, not on the value expression that follows the colon.
+    if (!PsiTreeUtil.isAncestor(key, sourceElement, false)) return null;
+
+    HaxeObjectLiteral objectLiteral = PsiTreeUtil.getParentOfType(literalElement, HaxeObjectLiteral.class);
+    if (objectLiteral == null) return null;
+
+    HaxeGenericResolver resolver = new HaxeGenericResolver();
+    ResultHolder expectedType =
+      HaxeExpressionEvaluator.findObjectLiteralType(new HaxeExpressionEvaluatorContext(objectLiteral), resolver, objectLiteral);
+    if (expectedType == null || expectedType.isUnknown()) {
+      // findObjectLiteralType only understands a few direct contexts (assignment, return, var init,
+      // plain call). Fall back to the resolver's full finder, which also handles constructor
+      // arguments and literals nested inside arrays or other object literals.
+      expectedType = HaxeResolver.getInstance(objectLiteral.getProject()).findExpectedType(objectLiteral);
+    }
+    if (expectedType == null || expectedType.isUnknown()) return null;
+
+    SpecificHaxeClassReference classType = expectedType.getClassType();
+    if (classType == null) return null;
+
+    HaxeClassModel classModel = classType.getHaxeClassModel();
+    if (classModel == null) return null;
+
+    HaxeBaseMemberModel member = classModel.getMember(literalElement.getName(), classType.getGenericResolver());
+    if (member == null) return null;
+
+    PsiElement declaration = member.getNameOrBasePsi();
+    // Don't offer a target that points back into the literal we started from.
+    if (declaration == null || PsiTreeUtil.isAncestor(objectLiteral, declaration, false)) return null;
+
+    return new PsiElement[]{declaration};
+  }
+}

--- a/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
+++ b/src/main/java/com/intellij/plugins/haxe/lang/psi/HaxeResolver.java
@@ -448,6 +448,18 @@ public final class HaxeResolver implements ResolveCache.AbstractResolver<HaxeRef
   }
 
 
+  /**
+   * Determines the type that {@code expression} is expected to conform to from its surrounding
+   * context: a variable type tag, a return type, a call or constructor argument, or an enclosing
+   * array / object literal field. Nested arrays and object literals are unwrapped recursively, so
+   * e.g. the element type of {@code new Foo({items: [ {...} ]})} can be found from the inner literal.
+   * Returns {@code null} when no expected type can be determined.
+   */
+  @Nullable
+  public ResultHolder findExpectedType(@NotNull PsiElement expression) {
+    return findParentAssignType(expression, true);
+  }
+
   // Experimental
   // try to step one level up until we find a type definition and then pass that back down
   private ResultHolder findParentAssignType(@NotNull PsiElement reference) {

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -57,6 +57,7 @@
 
     <iconProvider implementation="com.intellij.plugins.haxe.ide.HaxeIconProvider"/>
     <qualifiedNameProvider implementation="com.intellij.plugins.haxe.ide.HaxeQualifiedNameProvider"/>
+    <gotoDeclarationHandler implementation="com.intellij.plugins.haxe.ide.HaxeGotoDeclarationHandler"/>
 
     <sdkType implementation="com.intellij.plugins.haxe.config.sdk.HaxeSdkType"/>
     <compiler.task implementation="com.intellij.plugins.haxe.compilation.HaxeCompilerTask"/>

--- a/src/test/java/com/intellij/plugins/haxe/actions/HaxeGoToDeclarationActionTest.java
+++ b/src/test/java/com/intellij/plugins/haxe/actions/HaxeGoToDeclarationActionTest.java
@@ -18,10 +18,15 @@
 package com.intellij.plugins.haxe.actions;
 
 import com.intellij.codeInsight.TargetElementUtil;
+import com.intellij.codeInsight.navigation.actions.GotoDeclarationAction;
 import com.intellij.plugins.haxe.HaxeCodeInsightFixtureTestCase;
+import com.intellij.plugins.haxe.lang.psi.HaxeComponentName;
+import com.intellij.plugins.haxe.lang.psi.HaxeObjectLiteral;
+import com.intellij.plugins.haxe.lang.psi.HaxeTypedefDeclaration;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiReference;
+import com.intellij.psi.util.PsiTreeUtil;
 import org.junit.Test;
 
 import java.util.Collection;
@@ -392,5 +397,96 @@ public class HaxeGoToDeclarationActionTest extends HaxeCodeInsightFixtureTestCas
   @Test
   public void testTypeCheckExpression1() {
     doTest(myFixture.configureByFiles("TypeCheckExpression1.hx"), 1);
+  }
+
+  @Test
+  public void testObjectLiteralKeyResolvesToTypedefField() {
+    myFixture.configureByFiles("ObjectLiteralKey.hx");
+    PsiElement target = singleGotoTarget();
+    assertEquals("name", resolvedName(target));
+    assertNull("should navigate to the typedef field, not stay on the object literal key",
+               PsiTreeUtil.getParentOfType(target, HaxeObjectLiteral.class, false));
+    HaxeTypedefDeclaration typedef = PsiTreeUtil.getParentOfType(target, HaxeTypedefDeclaration.class);
+    assertNotNull("target should be declared inside a typedef", typedef);
+    assertEquals("Config", typedef.getComponentName().getText());
+  }
+
+  @Test
+  public void testObjectLiteralKeyResolvesThroughExtendedTypedef() {
+    myFixture.configureByFiles("ObjectLiteralKeyExtends.hx");
+    PsiElement target = singleGotoTarget();
+    assertEquals("label", resolvedName(target));
+    HaxeTypedefDeclaration typedef = PsiTreeUtil.getParentOfType(target, HaxeTypedefDeclaration.class);
+    assertNotNull("target should be declared inside a typedef", typedef);
+    assertEquals("label is declared in the parent typedef Base", "Base", typedef.getComponentName().getText());
+  }
+
+  @Test
+  public void testObjectLiteralKeyResolvesThroughIntersectionTypedef() {
+    myFixture.configureByFiles("ObjectLiteralKeyIntersection.hx");
+    PsiElement target = singleGotoTarget();
+    assertEquals("alpha", resolvedName(target));
+    assertNull("should navigate to the typedef field, not stay on the object literal key",
+               PsiTreeUtil.getParentOfType(target, HaxeObjectLiteral.class, false));
+    HaxeTypedefDeclaration typedef = PsiTreeUtil.getParentOfType(target, HaxeTypedefDeclaration.class);
+    assertNotNull("target should be declared inside a typedef", typedef);
+    assertEquals("Combo", typedef.getComponentName().getText());
+  }
+
+  @Test
+  public void testObjectLiteralKeyInConstructorArgument() {
+    myFixture.configureByFiles("ConstructorArgKey.hx");
+    PsiElement target = singleGotoTarget();
+    assertEquals("items", resolvedName(target));
+    HaxeTypedefDeclaration typedef = PsiTreeUtil.getParentOfType(target, HaxeTypedefDeclaration.class);
+    assertNotNull("target should be declared inside a typedef", typedef);
+    assertEquals("ContainerConfig", typedef.getComponentName().getText());
+  }
+
+  @Test
+  public void testObjectLiteralKeyNestedInArrayArgument() {
+    myFixture.configureByFiles("ConstructorArgNestedArrayKey.hx");
+    PsiElement target = singleGotoTarget();
+    assertEquals("itemId", resolvedName(target));
+    HaxeTypedefDeclaration typedef = PsiTreeUtil.getParentOfType(target, HaxeTypedefDeclaration.class);
+    assertNotNull("target should be declared inside a typedef", typedef);
+    assertEquals("ItemConfig", typedef.getComponentName().getText());
+  }
+
+  @Test
+  public void testObjectLiteralKeyNestedInArrayThroughIntersection() {
+    myFixture.configureByFiles("ConstructorArgIntersectionKey.hx");
+    PsiElement target = singleGotoTarget();
+    assertEquals("flag", resolvedName(target));
+    HaxeTypedefDeclaration typedef = PsiTreeUtil.getParentOfType(target, HaxeTypedefDeclaration.class);
+    assertNotNull("target should be declared inside a typedef", typedef);
+    assertEquals("ExtraConfig", typedef.getComponentName().getText());
+  }
+
+  @Test
+  public void testObjectLiteralKeyNestedInOptionalArrayArgument() {
+    myFixture.configureByFiles("ConstructorArgOptionalArrayKey.hx");
+    PsiElement target = singleGotoTarget();
+    assertEquals("key", resolvedName(target));
+    HaxeTypedefDeclaration typedef = PsiTreeUtil.getParentOfType(target, HaxeTypedefDeclaration.class);
+    assertNotNull("target should be declared inside a typedef", typedef);
+    assertEquals("EntryConfig", typedef.getComponentName().getText());
+  }
+
+  /** Runs the real go-to-declaration pipeline (handlers + reference resolution) and expects a single target. */
+  private PsiElement singleGotoTarget() {
+    PsiElement[] targets = GotoDeclarationAction.findAllTargetElements(
+      myFixture.getProject(), myFixture.getEditor(), myFixture.getCaretOffset());
+    assertNotNull(targets);
+    assertEquals("expected exactly one navigation target", 1, targets.length);
+    return targets[0];
+  }
+
+  private static String resolvedName(PsiElement target) {
+    if (target instanceof HaxeComponentName componentName) {
+      return componentName.getText();
+    }
+    HaxeComponentName componentName = PsiTreeUtil.findChildOfType(target, HaxeComponentName.class);
+    return componentName != null ? componentName.getText() : target.getText();
   }
 }

--- a/src/test/resources/testData/goto/ConstructorArgIntersectionKey.hx
+++ b/src/test/resources/testData/goto/ConstructorArgIntersectionKey.hx
@@ -1,0 +1,25 @@
+class ConstructorArgIntersectionKey {
+    public static function main() {
+        new Container({
+            items: [
+                {itemId: 1, fl<caret>ag: true}
+            ],
+        });
+    }
+}
+
+class Container {
+    public function new(config:ContainerConfig) {}
+}
+
+typedef ContainerConfig = {
+    var items:Array<ItemConfig>;
+}
+
+typedef ItemConfig = {
+    var itemId:Int;
+} & ExtraConfig;
+
+typedef ExtraConfig = {
+    var ?flag:Bool;
+}

--- a/src/test/resources/testData/goto/ConstructorArgKey.hx
+++ b/src/test/resources/testData/goto/ConstructorArgKey.hx
@@ -1,0 +1,22 @@
+class ConstructorArgKey {
+    public static function main() {
+        new Container({
+            it<caret>ems: [
+                {itemId: 1}
+            ],
+        });
+    }
+}
+
+class Container {
+    public function new(config:ContainerConfig) {}
+}
+
+typedef ContainerConfig = {
+    var items:Array<ItemConfig>;
+    var ?labels:Array<String>;
+}
+
+typedef ItemConfig = {
+    var itemId:Int;
+}

--- a/src/test/resources/testData/goto/ConstructorArgNestedArrayKey.hx
+++ b/src/test/resources/testData/goto/ConstructorArgNestedArrayKey.hx
@@ -1,0 +1,21 @@
+class ConstructorArgNestedArrayKey {
+    public static function main() {
+        new Container({
+            items: [
+                {item<caret>Id: 1}
+            ],
+        });
+    }
+}
+
+class Container {
+    public function new(config:ContainerConfig) {}
+}
+
+typedef ContainerConfig = {
+    var items:Array<ItemConfig>;
+}
+
+typedef ItemConfig = {
+    var itemId:Int;
+}

--- a/src/test/resources/testData/goto/ConstructorArgOptionalArrayKey.hx
+++ b/src/test/resources/testData/goto/ConstructorArgOptionalArrayKey.hx
@@ -1,0 +1,21 @@
+class ConstructorArgOptionalArrayKey {
+    public static function main() {
+        new Container({
+            entries: [
+                {ke<caret>y: "a"}
+            ],
+        });
+    }
+}
+
+class Container {
+    public function new(config:ContainerConfig) {}
+}
+
+typedef ContainerConfig = {
+    var ?entries:Array<EntryConfig>;
+}
+
+typedef EntryConfig = {
+    var key:String;
+}

--- a/src/test/resources/testData/goto/ObjectLiteralKey.hx
+++ b/src/test/resources/testData/goto/ObjectLiteralKey.hx
@@ -1,0 +1,13 @@
+class ObjectLiteralKey {
+    public static function main() {
+        var config:Config = {
+            na<caret>me: "value",
+            size: 1,
+        };
+    }
+}
+
+typedef Config = {
+    var name:String;
+    var size:Int;
+}

--- a/src/test/resources/testData/goto/ObjectLiteralKeyExtends.hx
+++ b/src/test/resources/testData/goto/ObjectLiteralKeyExtends.hx
@@ -1,0 +1,17 @@
+class ObjectLiteralKeyExtends {
+    public static function main() {
+        var widget:Widget = {
+            la<caret>bel: "value",
+            width: 1,
+        };
+    }
+}
+
+typedef Base = {
+    var label:String;
+}
+
+typedef Widget = {
+    > Base,
+    var width:Int;
+}

--- a/src/test/resources/testData/goto/ObjectLiteralKeyIntersection.hx
+++ b/src/test/resources/testData/goto/ObjectLiteralKeyIntersection.hx
@@ -1,0 +1,10 @@
+class ObjectLiteralKeyIntersection {
+    public static function main() {
+        var combo:Combo = {
+            al<caret>pha: 1,
+            beta: "value",
+        };
+    }
+}
+
+typedef Combo = {alpha:Int} & {beta:String};


### PR DESCRIPTION
Hi! 👋
This adds go-to-declaration on typedef keys so we can CTRL/CMD+Click directly to declarations.
There's a new handler that works out the expected type from context and jumps to the matching field.

This is for navigation only without touching rename/find-usages, etc. Covered with tests for different contexts.